### PR TITLE
Mandatory human-review UI before report_issue files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Open source, early access — APIs unstable. The 11 stable MCP categories (actor
 
 > ⚠️ **Security note** — the `ue5_run_python` tool executes arbitrary Python inside the UE5 editor with full filesystem + process access. Treat any Claude/MCP session you run against Arbor the same way you'd treat running code from a peer reviewer. Don't expose the Remote Control API port (30010) outside localhost.
 
-> ⚠️ **Issue filing is public by default.** The `report_issue` MCP tool files bug reports on whatever `GITHUB_TRACKER_REPO` you configure (default: `ArborSmith/arbor` — public). Claude is instructed (via the tool schema and `CLAUDE.md`) to substitute project-specific identifiers (asset paths, Blueprint/class/level/character names, IP references, absolute filesystem paths) with generic placeholders before submitting — but if your UE5 project is confidential, **review the generated issue before it's sent**, or point `GITHUB_TRACKER_REPO` at a tracker you control to keep issues private.
+> ⚠️ **Issue filing is public by default.** The `report_issue` MCP tool files bug reports on whatever `GITHUB_TRACKER_REPO` you configure (default: `ArborSmith/arbor` — public). Two-layer guard before anything ships:
+>
+> 1. Claude is instructed (via the tool schema and `CLAUDE.md`) to substitute project-specific identifiers (asset paths, Blueprint/class/level/character names, IP references, absolute filesystem paths) with generic placeholders before submitting.
+> 2. The bridge opens a **local browser-based review UI** showing the rendered title and body, with editable fields and a generic-leak scanner. Click Submit to file, Cancel to abort. You are the final checkpoint.
+>
+> Bypass the review UI for headless/CI contexts with `ARBOR_ISSUE_REVIEW=skip`. Point `GITHUB_TRACKER_REPO` at a tracker you control to keep issues private.
 
 ### 1 — Install the plugin
 

--- a/bridge/CLAUDE.md
+++ b/bridge/CLAUDE.md
@@ -83,6 +83,8 @@ Result drives which categories `index.ts` registers.
 
 `report_issue` MCP tool creates a GitHub issue via the `gh` CLI in the repo named by `GITHUB_TRACKER_REPO` env var (default: `ArborSmith/arbor`). Requires `gh` to be installed and authenticated.
 
+**Mandatory human review before send.** The tool spins up a local HTTP server (`issue-review-server.ts` + `static/issue-review.html`) on a random localhost port, opens the user's default browser to a review page, and blocks until the user clicks Submit or Cancel. Submitted edits to title/body win. Bypass for headless/CI contexts: `ARBOR_ISSUE_REVIEW=skip`. The review UI runs a generic client-side leak scanner (absolute paths, emails, IPs) — project-specific naming still relies on Claude's pre-submit sanitization (per the schema descriptions in `tools/core/report-issue.ts`).
+
 ## Setup
 
 ### UE5 side (one-time)

--- a/bridge/src/issue-review-server.ts
+++ b/bridge/src/issue-review-server.ts
@@ -1,0 +1,152 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const STATIC_DIR = resolve(__dirname, "..", "static");
+const TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+export interface IssueReviewInput {
+  title: string;
+  body: string;
+  repo: string;
+}
+
+export interface IssueReviewResult {
+  action: "confirm" | "cancel";
+  title?: string;
+  body?: string;
+}
+
+export interface StartedReview {
+  url: Promise<string>;
+  result: Promise<IssueReviewResult>;
+}
+
+function collectBody(req: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolveBody, rejectBody) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolveBody(Buffer.concat(chunks)));
+    req.on("error", rejectBody);
+  });
+}
+
+/**
+ * Spin up a local HTTP server hosting the issue-review UI. Caller is
+ * expected to open the returned URL in a browser; the result Promise
+ * resolves once the user clicks Submit or Cancel (or rejects on timeout).
+ */
+export function startIssueReviewServer(input: IssueReviewInput): StartedReview {
+  let resolveUrl!: (url: string) => void;
+  let rejectUrl!: (err: Error) => void;
+  let resolveResult!: (r: IssueReviewResult) => void;
+  let rejectResult!: (err: Error) => void;
+
+  const urlPromise = new Promise<string>((res, rej) => {
+    resolveUrl = res;
+    rejectUrl = rej;
+  });
+  const resultPromise = new Promise<IssueReviewResult>((res, rej) => {
+    resolveResult = res;
+    rejectResult = rej;
+  });
+
+  let settled = false;
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+      if (req.method === "GET" && url.pathname === "/") {
+        const html = await readFile(join(STATIC_DIR, "issue-review.html"));
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(html);
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === "/api/issue") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(input));
+        return;
+      }
+
+      if (req.method === "POST" && url.pathname === "/api/submit") {
+        const body = await collectBody(req);
+        let payload: { action?: string; title?: string; body?: string };
+        try {
+          payload = JSON.parse(body.toString("utf8")) as { action?: string; title?: string; body?: string };
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Invalid JSON" }));
+          return;
+        }
+
+        const action: "confirm" | "cancel" = payload.action === "confirm" ? "confirm" : "cancel";
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+
+        if (!settled) {
+          settled = true;
+          cleanup();
+          if (action === "confirm") {
+            resolveResult({
+              action,
+              title: payload.title ?? input.title,
+              body: payload.body ?? input.body,
+            });
+          } else {
+            resolveResult({ action: "cancel" });
+          }
+        }
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    } catch (err) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: String(err) }));
+    }
+  });
+
+  const timer = setTimeout(() => {
+    if (!settled) {
+      settled = true;
+      cleanup();
+      rejectResult(new Error("Issue review timed out (10 minutes). User did not respond."));
+    }
+  }, TIMEOUT_MS);
+
+  function cleanup() {
+    clearTimeout(timer);
+    server.close();
+  }
+
+  server.listen(0, "127.0.0.1", () => {
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      resolveUrl(`http://127.0.0.1:${addr.port}/`);
+    } else {
+      const err = new Error("Failed to determine review-server address");
+      rejectUrl(err);
+      if (!settled) {
+        settled = true;
+        cleanup();
+        rejectResult(err);
+      }
+    }
+  });
+
+  server.on("error", (err) => {
+    if (!settled) {
+      settled = true;
+      cleanup();
+      rejectUrl(err);
+      rejectResult(err);
+    }
+  });
+
+  return { url: urlPromise, result: resultPromise };
+}

--- a/bridge/src/tools/core/report-issue.ts
+++ b/bridge/src/tools/core/report-issue.ts
@@ -1,8 +1,23 @@
 import { z } from "zod";
-import { execFile } from "node:child_process";
+import { execFile, exec } from "node:child_process";
 import { promisify } from "node:util";
+import { startIssueReviewServer } from "../../issue-review-server.js";
 
 const execFileAsync = promisify(execFile);
+
+// Spawn the platform's URL handler. Best-effort — failure to auto-open is
+// not fatal; the URL is also logged to stderr so the user can click it.
+function openInBrowser(url: string): void {
+  let cmd: string;
+  if (process.platform === "win32") cmd = `start "" "${url}"`;
+  else if (process.platform === "darwin") cmd = `open "${url}"`;
+  else cmd = `xdg-open "${url}"`;
+  exec(cmd, (err) => {
+    if (err) {
+      console.error(`[ue5-bridge] Could not auto-open browser: ${err.message}`);
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -129,7 +144,7 @@ async function createGithubIssue(
     params.description.length > 80
       ? params.description.slice(0, 77).replace(/\s+\S*$/, "") + "..."
       : params.description;
-  const title = `${prefix}${moduleTag} ${shortDesc}`;
+  let title = `${prefix}${moduleTag} ${shortDesc}`;
 
   // Build body (GitHub-flavored Markdown)
   const bodyLines: string[] = [];
@@ -161,8 +176,30 @@ async function createGithubIssue(
 
   bodyLines.push("---", "*Reported automatically by Claude via ue5-bridge MCP.*");
 
-  const body = bodyLines.join("\n");
+  let body = bodyLines.join("\n");
   const label = params.type === "bug" ? "bug" : "feature-request";
+
+  // Human review checkpoint. Default ON. Set ARBOR_ISSUE_REVIEW=skip to bypass
+  // (useful for headless / CI contexts). Returning "cancel" aborts the file.
+  if ((process.env.ARBOR_ISSUE_REVIEW || "").toLowerCase() !== "skip") {
+    console.error(`[ue5-bridge] Opening issue review UI; awaiting user confirmation...`);
+    try {
+      const { url, result } = startIssueReviewServer({ repo, title, body });
+      const reviewUrl = await url;
+      console.error(`[ue5-bridge] Review at: ${reviewUrl}`);
+      openInBrowser(reviewUrl);
+      const review = await result;
+      if (review.action === "cancel") {
+        return { sent: false, message: "User cancelled the issue submission via the review UI." };
+      }
+      // User-edited values win
+      title = review.title ?? title;
+      body = review.body ?? body;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { sent: false, message: `Issue review failed: ${msg}` };
+    }
+  }
 
   console.error(`[ue5-bridge] Creating GitHub issue in ${repo}`);
 

--- a/bridge/static/issue-review.html
+++ b/bridge/static/issue-review.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Review Arbor issue</title>
+<style>
+  body {
+    font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+    max-width: 920px;
+    margin: 2em auto;
+    padding: 0 1.5em 4em;
+    color: #1f2328;
+    background: #fff;
+  }
+  h1 { font-size: 1.35em; margin-bottom: 0.4em; }
+  .sub { color: #57606a; margin-bottom: 1.5em; font-size: 0.95em; }
+  .repo { font-family: ui-monospace, "SFMono-Regular", Consolas, monospace; background: #eaeef2; padding: 1px 6px; border-radius: 3px; }
+  .banner { padding: 12px 16px; border-radius: 6px; margin-bottom: 1.25em; line-height: 1.4; }
+  .banner.warn { background: #fff8c5; border: 1px solid #d4a72c; }
+  .banner.danger { background: #ffebe9; border: 1px solid #cf222e; }
+  .banner ul { margin: 0.5em 0 0; padding-left: 1.5em; }
+  .banner code { background: rgba(0,0,0,0.08); padding: 1px 5px; border-radius: 3px; }
+  .field { margin-bottom: 1em; }
+  label { display: block; font-weight: 600; margin-bottom: 4px; font-size: 0.92em; }
+  input, textarea {
+    width: 100%; padding: 8px 10px;
+    border: 1px solid #d0d7de; border-radius: 4px;
+    font-family: inherit; font-size: 0.95em;
+    box-sizing: border-box; background: #fff; color: #1f2328;
+  }
+  input:focus, textarea:focus { outline: 2px solid #0969da; outline-offset: -1px; border-color: #0969da; }
+  textarea {
+    font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+    min-height: 380px; line-height: 1.45; resize: vertical;
+  }
+  .buttons { display: flex; gap: 12px; margin-top: 1.5em; align-items: center; }
+  button { padding: 9px 20px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.95em; border: 1px solid; }
+  button.primary { background: #1f883d; color: #fff; border-color: #1a7c34; }
+  button.primary:hover { background: #1a7c34; }
+  button.primary:disabled { background: #94d3a2; border-color: #94d3a2; cursor: not-allowed; }
+  button.secondary { background: #f6f8fa; color: #1f2328; border-color: #d0d7de; }
+  button.secondary:hover { background: #f0f3f6; }
+  .hint { color: #57606a; font-size: 0.88em; margin-left: auto; }
+  .done { text-align: center; padding: 4em 1em; font-size: 1.15em; color: #1f883d; }
+  .done.cancelled { color: #57606a; }
+</style>
+</head>
+<body>
+<div id="app">Loading…</div>
+<script>
+"use strict";
+
+// Generic safety scanner: catches things almost-always considered leaks
+// regardless of project. Project-specific names (e.g. parent project IP)
+// require human review — that's why this whole UI exists.
+const LEAK_PATTERNS = [
+  { name: "Absolute Windows path",  re: /\b[A-Z]:[\\/][\w\s.\-\\/]{2,}/g },
+  { name: "Unix /home or /Users path", re: /\/(?:home|Users|root)\/[\w.\-]+(?:\/[\w.\-]+)*/g },
+  { name: "Email address",          re: /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g },
+  { name: "IPv4 address",           re: /\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}\b/g },
+];
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => (
+    { "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#39;" }[c]
+  ));
+}
+
+function scanForLeaks(text) {
+  const hits = [];
+  for (const p of LEAK_PATTERNS) {
+    p.re.lastIndex = 0;
+    let m;
+    while ((m = p.re.exec(text)) !== null) {
+      hits.push({ name: p.name, match: m[0] });
+      if (hits.length >= 50) return hits;
+    }
+  }
+  return hits;
+}
+
+async function load() {
+  const res = await fetch("/api/issue");
+  if (!res.ok) {
+    document.getElementById("app").textContent = "Failed to load issue payload.";
+    return;
+  }
+  render(await res.json());
+}
+
+function render(data) {
+  document.getElementById("app").innerHTML = `
+    <h1>Review Arbor issue before sending</h1>
+    <div class="sub">
+      Filing target: <span class="repo">${escapeHtml(data.repo)}</span> &nbsp;·&nbsp;
+      Issues are public. Edit anything you don't want public, then click Submit. Cancel aborts and sends nothing.
+    </div>
+
+    <div class="banner warn">
+      <strong>Heads up:</strong> Arbor instructs Claude to substitute project-specific names with placeholders before invoking <code>report_issue</code>. This page is your final human checkpoint — you are the last line of defense before this content becomes public.
+    </div>
+
+    <div id="leak-banner"></div>
+
+    <div class="field">
+      <label for="title">Title</label>
+      <input id="title" type="text" value="${escapeHtml(data.title)}">
+    </div>
+
+    <div class="field">
+      <label for="body">Body (Markdown)</label>
+      <textarea id="body" spellcheck="false">${escapeHtml(data.body)}</textarea>
+    </div>
+
+    <div class="buttons">
+      <button class="primary" id="submit">Submit to GitHub</button>
+      <button class="secondary" id="cancel">Cancel</button>
+      <span class="hint">You can close this tab after either action.</span>
+    </div>
+  `;
+
+  document.getElementById("submit").addEventListener("click", submit);
+  document.getElementById("cancel").addEventListener("click", cancel);
+  document.getElementById("title").addEventListener("input", scanCurrent);
+  document.getElementById("body").addEventListener("input", scanCurrent);
+  scanCurrent();
+}
+
+function scanCurrent() {
+  const title = document.getElementById("title").value;
+  const body = document.getElementById("body").value;
+  const hits = [...scanForLeaks(title), ...scanForLeaks(body)];
+  const banner = document.getElementById("leak-banner");
+  if (hits.length === 0) {
+    banner.innerHTML = "";
+    return;
+  }
+  const items = hits.slice(0, 12).map(h =>
+    `<li><code>${escapeHtml(h.match)}</code> — ${escapeHtml(h.name)}</li>`
+  ).join("");
+  const more = hits.length > 12 ? `<li>…and ${hits.length - 12} more</li>` : "";
+  banner.innerHTML = `
+    <div class="banner danger">
+      <strong>Possible leaks detected (${hits.length}):</strong> these patterns commonly indicate identifiers you don't want in a public issue. Review and edit, or click Cancel.
+      <ul>${items}${more}</ul>
+    </div>
+  `;
+}
+
+let posting = false;
+async function post(action) {
+  if (posting) return;
+  posting = true;
+  document.getElementById("submit").disabled = true;
+  const title = document.getElementById("title").value;
+  const body = document.getElementById("body").value;
+  try {
+    await fetch("/api/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action, title, body }),
+    });
+  } catch (e) { /* server may close immediately on success */ }
+  if (action === "confirm") {
+    show("Issue submitted to GitHub. You can close this tab.", false);
+  } else {
+    show("Cancelled. Nothing was sent. You can close this tab.", true);
+  }
+}
+
+function submit() { post("confirm"); }
+function cancel() { post("cancel"); }
+
+function show(msg, cancelled) {
+  document.getElementById("app").innerHTML =
+    `<div class="done${cancelled ? " cancelled" : ""}">${escapeHtml(msg)}</div>`;
+}
+
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a local browser-based review UI as the final checkpoint before any GitHub issue is filed via the `report_issue` MCP tool. Builds on #7's Claude-side sanitization rules — that's layer 1, this is layer 2 (you, the human).

### What it does

1. Claude calls `report_issue` as before.
2. Bridge formats the title + body but does **not** call `gh` yet.
3. Bridge spins up an HTTP server on a random localhost port and opens the user's default browser to the review page.
4. Review page shows:
   - Editable title + body
   - Filing target repo (read-only)
   - Generic-leak scanner highlighting absolute paths, emails, IPv4 (project-specific naming relies on Claude's pre-submit sanitization)
5. User clicks Submit (uses possibly-edited content) or Cancel (aborts, nothing sent). 10-minute timeout otherwise.

### Bypass

`ARBOR_ISSUE_REVIEW=skip` env var skips the review for headless / CI contexts.

### Files

- `bridge/static/issue-review.html` — review page (vanilla JS, no deps)
- `bridge/src/issue-review-server.ts` — HTTP server (mirrors `annotation-server.ts` pattern)
- `bridge/src/tools/core/report-issue.ts` — wires review server in front of `gh issue create`
- `README.md` — rewrites the issue-filing warning as a two-layer guard
- `bridge/CLAUDE.md` — explains the review flow + bypass env var

## Test plan

- [x] `npm run build` clean
- [ ] CI + gitleaks pass
- [ ] Manual: from a Claude session, ask it to file a synthetic bug. Verify the browser opens, the review page renders, both Submit and Cancel paths work, and the issue actually lands (or doesn't) accordingly.
- [ ] Manual: with `ARBOR_ISSUE_REVIEW=skip`, verify report_issue files directly without opening a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)