### PR TITLE
Fix in-editor chat launch on Windows (PATHEXT / cmd.exe wrapper)

### DIFF
--- a/Source/Arbor/Private/ArborChatWidget.cpp
+++ b/Source/Arbor/Private/ArborChatWidget.cpp
@@ -1052,7 +1052,6 @@ void SArborChatWidget::StartClaudeProcess(const FString& ResumeSessionId)
 	FPlatformProcess::WritePipe(StdInWritePipe, InitMsg);
 
 	FString WorkDir = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
-	FString ClaudePath = TEXT("claude");
 	FString Args = TEXT("--print --output-format stream-json --input-format stream-json --verbose");
 
 	// Permission handling: plan mode uses restricted permissions, edit mode skips all permissions
@@ -1081,9 +1080,25 @@ void SArborChatWidget::StartClaudeProcess(const FString& ResumeSessionId)
 		Args += FString::Printf(TEXT(" --resume %s"), *ResumeSessionId);
 	}
 
+	FString LaunchBinary = TEXT("claude");
+	FString LaunchArgs = Args;
+
+#if PLATFORM_WINDOWS
+	// CreateProcessW does not resolve PATHEXT (.exe / .cmd / .bat), so
+	// `claude` alone fails when Claude Code is installed via npm — its
+	// executable is `claude.cmd`, found by cmd.exe but invisible to a raw
+	// CreateProcessW call. Symptom: in-editor chat says "claude not on
+	// PATH" while `claude` works fine from a regular cmd prompt. Route
+	// through cmd.exe so its PATHEXT lookup runs first. /s + the outer
+	// quotes ensure cmd strips exactly one quote pair, leaving any
+	// argument-internal quotes (like --allowedTools "Read Glob ...") intact.
+	LaunchBinary = TEXT("cmd.exe");
+	LaunchArgs = FString::Printf(TEXT("/s /c \"claude %s\""), *Args);
+#endif
+
 	ClaudeProcess = FPlatformProcess::CreateProc(
-		*ClaudePath,
-		*Args,
+		*LaunchBinary,
+		*LaunchArgs,
 		false,      // bLaunchDetached
 		true,       // bLaunchHidden
 		true,       // bLaunchReallyHidden
@@ -1109,7 +1124,7 @@ void SArborChatWidget::StartClaudeProcess(const FString& ResumeSessionId)
 	{
 		bProcessRunning = false;
 		SetStatus(TEXT(""));
-		AddMessage(EArborMessageType::System, TEXT("Failed to start Claude. Make sure 'claude' is on your PATH."));
+		AddMessage(EArborMessageType::System, TEXT("Failed to start Claude. Make sure the Claude Code CLI is installed and on your PATH (claude / claude.exe / claude.cmd)."));
 		FinalizeCurrentMessage();
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a Windows-only bug where the in-editor Arbor Chat tab reports `Failed to start Claude. Make sure 'claude' is on your PATH.` even when `claude` runs fine from a regular cmd prompt.

### Root cause

`FPlatformProcess::CreateProc` on Windows ultimately calls `CreateProcessW`, which **does not** perform PATHEXT lookup. Claude Code installed via npm produces `claude.cmd` (a batch shim that calls `node.exe` against the JS entrypoint). `cmd.exe` resolves `claude` → `claude.cmd` via PATHEXT; raw `CreateProcessW` does not.

### Fix

On Windows, wrap the launch through `cmd.exe /s /c "claude <args>"`. cmd's PATHEXT lookup picks up `claude.cmd` (or `claude.exe` if present); pipes are passed through transparently. `/s` + outer quotes ensures cmd strips exactly the wrapper quote pair, leaving argument-internal quotes (e.g. `--allowedTools "Read Glob ..."`) intact. Non-Windows paths are unchanged.

Error message also updated to mention `.exe` / `.cmd` variants so users know what gets accepted.

## Test plan

- [ ] CI + gitleaks pass
- [ ] Manual on Windows with npm-installed Claude Code: open the Arbor Chat tab, confirm Claude starts (no "not on PATH" error)
- [ ] Manual on macOS / Linux: confirm no regression — chat still launches normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)