### PR TITLE
Compile cleanly against UE 5.4 through 5.7

### DIFF
--- a/Arbor.uplugin
+++ b/Arbor.uplugin
@@ -4,7 +4,6 @@
 	"VersionName": "0.1",
 	"FriendlyName": "Arbor",
 	"Description": "AI-driven gamedev toolkit — BehaviorTree, Blueprint, EQS, Terrain, PCG builders plus a Python utility library that lets Claude build game content directly in the editor.",
-	"EngineVersion": "5.4.0",
 	"Category": "AI",
 	"CreatedBy": "Arbor",
 	"CanContainContent": true,

--- a/Source/Arbor/Private/ArborAutomationTools.cpp
+++ b/Source/Arbor/Private/ArborAutomationTools.cpp
@@ -6,6 +6,16 @@
 #include "Misc/DateTime.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
+#include "Runtime/Launch/Resources/Version.h"
+
+// EAutomationTestFlags::FilterMask (a value inside the enum) was replaced with
+// the free constant EAutomationTestFlags_FilterMask in UE 5.5 when the enum was
+// converted to enum-class.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+	#define ARBOR_AUTOMATION_FILTER_MASK EAutomationTestFlags_FilterMask
+#else
+	#define ARBOR_AUTOMATION_FILTER_MASK EAutomationTestFlags::FilterMask
+#endif
 
 namespace ArborAutomationToolsInternal
 {
@@ -43,7 +53,7 @@ namespace ArborAutomationToolsInternal
 	 */
 	static void EnsureWideTestFilter()
 	{
-		FAutomationTestFramework::Get().SetRequestedTestFilter(EAutomationTestFlags::FilterMask);
+		FAutomationTestFramework::Get().SetRequestedTestFilter(ARBOR_AUTOMATION_FILTER_MASK);
 	}
 
 	/** Collect every valid test info whose full path matches Filter. */

--- a/Source/Arbor/Private/LandscapeBuilder.cpp
+++ b/Source/Arbor/Private/LandscapeBuilder.cpp
@@ -12,32 +12,63 @@
 #include "LandscapeLayerInfoObject.h"
 #include "Runtime/Launch/Resources/Version.h"
 
-// UE 5.5 introduced LandscapeEditLayer.h + ULandscapeEditLayerBase + ALandscape::GetEditLayer().
-// Before 5.5, edit layers lived on ALandscape::LandscapeLayers as FLandscapeLayer structs.
-// We hide the split behind GetFirstEditLayerGuid() below.
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-#define ARBOR_HAS_UE55_EDIT_LAYERS 1
-#include "LandscapeEditLayer.h"
+// Edit-layer API timeline (verified against engine headers):
+//   5.4:    ALandscape::LandscapeLayers (TArray<FLandscapeLayer>) -- direct array access.
+//   5.5:    ALandscape::LandscapeLayers_DEPRECATED -- same struct, renamed UPROPERTY,
+//           ULandscapeEditLayerBase exists but ALandscape::GetEditLayer(int) does NOT.
+//   5.6+:   ALandscape::GetEditLayer(int) -> ULandscapeEditLayerBase*, plus
+//           ULandscapeEditLayerBase::GetGuid(). LandscapeLayers_DEPRECATED still
+//           present but accessors are preferred.
+//
+//   ULandscapeLayerInfoObject::SetLayerName / GetLayerName landed in 5.7;
+//   before that the LayerName UPROPERTY is read/written directly.
+//
+// We hide both splits behind helpers below.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
+	#define ARBOR_HAS_GET_EDIT_LAYER 1
+	#include "LandscapeEditLayer.h"
 #else
-#define ARBOR_HAS_UE55_EDIT_LAYERS 0
+	#define ARBOR_HAS_GET_EDIT_LAYER 0
+#endif
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7)
+	#define ARBOR_HAS_LAYER_NAME_ACCESSORS 1
+#else
+	#define ARBOR_HAS_LAYER_NAME_ACCESSORS 0
+#endif
+
+// ALandscape::Import(...) final argument signature:
+//   5.4:   const TArray<FLandscapeLayer>* (nullable pointer)
+//   5.5+:  const TArray<FLandscapeLayer>& (reference; pass empty array for none)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+	#define ARBOR_LANDSCAPE_IMPORT_BY_REF 1
+#else
+	#define ARBOR_LANDSCAPE_IMPORT_BY_REF 0
 #endif
 
 namespace
 {
 	// Returns the GUID of the first (base) edit layer on a landscape, or an empty
-	// FGuid if the landscape has no edit layers. Abstracts over the UE 5.4 vs 5.5+
-	// edit-layer API change so builders compile cleanly against either version.
+	// FGuid if the landscape has no edit layers. Abstracts over the 5.4 / 5.5 /
+	// 5.6+ API splits so builders compile cleanly against any of them.
 	FGuid GetFirstEditLayerGuid(ALandscape* LandscapeActor)
 	{
 		if (!LandscapeActor)
 		{
 			return FGuid();
 		}
-#if ARBOR_HAS_UE55_EDIT_LAYERS
+#if ARBOR_HAS_GET_EDIT_LAYER
 		if (ULandscapeEditLayerBase* BaseLayer = LandscapeActor->GetEditLayer(0))
 		{
 			return BaseLayer->GetGuid();
 		}
+#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 5
+		PRAGMA_DISABLE_DEPRECATION_WARNINGS
+		if (LandscapeActor->LandscapeLayers_DEPRECATED.Num() > 0)
+		{
+			return LandscapeActor->LandscapeLayers_DEPRECATED[0].Guid;
+		}
+		PRAGMA_ENABLE_DEPRECATION_WARNINGS
 #else
 		if (LandscapeActor->LandscapeLayers.Num() > 0)
 		{
@@ -47,13 +78,11 @@ namespace
 		return FGuid();
 	}
 
-	// ULandscapeLayerInfoObject gained SetLayerName()/GetLayerName() accessors in
-	// UE 5.5. On 5.4 the LayerName UPROPERTY is read/written directly.
 	void SetLayerInfoName(ULandscapeLayerInfoObject* LayerInfo, FName Name)
 	{
 		if (!LayerInfo) return;
-#if ARBOR_HAS_UE55_EDIT_LAYERS
-		LayerInfo->SetLayerName(Name, /*bModifyPackage=*/false);
+#if ARBOR_HAS_LAYER_NAME_ACCESSORS
+		LayerInfo->SetLayerName(Name, /*bInModify=*/false);
 #else
 		LayerInfo->LayerName = Name;
 #endif
@@ -62,7 +91,7 @@ namespace
 	FName GetLayerInfoName(ULandscapeLayerInfoObject* LayerInfo)
 	{
 		if (!LayerInfo) return NAME_None;
-#if ARBOR_HAS_UE55_EDIT_LAYERS
+#if ARBOR_HAS_LAYER_NAME_ACCESSORS
 		return LayerInfo->GetLayerName();
 #else
 		return LayerInfo->LayerName;
@@ -270,9 +299,9 @@ ALandscape* ULandscapeBuilder::CreateLandscape(
 	TMap<FGuid, TArray<FLandscapeImportLayerInfo>> MaterialLayerDataPerLayers;
 	MaterialLayerDataPerLayers.Add(FGuid(), TArray<FLandscapeImportLayerInfo>());
 
-	// Import — final edit-layers argument: 5.4 expects `const TArray<FLandscapeLayer>*`
+	// Import -- final edit-layers argument: 5.4 expects `const TArray<FLandscapeLayer>*`
 	// (pointer, nullptr allowed to mean "no layers"); 5.5+ takes the array directly.
-#if ARBOR_HAS_UE55_EDIT_LAYERS
+#if ARBOR_LANDSCAPE_IMPORT_BY_REF
 	TArray<FLandscapeLayer> EmptyLayers;
 	Landscape->Import(
 		FGuid::NewGuid(),


### PR DESCRIPTION
## Summary

- `ArborAutomationTools.cpp`: gate `EAutomationTestFlags::FilterMask` (5.4) vs `EAutomationTestFlags_FilterMask` (5.5+) at the one call site in `EnsureWideTestFilter`.
- `LandscapeBuilder.cpp`: replace one inaccurate macro with three accurate version gates — `GetEditLayer/GetGuid` (5.6+), `SetLayerName/GetLayerName` (5.7+), and `Import(...)` final-arg pointer-to-reference (5.5+). Adds a 5.5 fallback path using `LandscapeLayers_DEPRECATED` wrapped in pragma deprecation guards.
- `Arbor.uplugin`: drop the `"EngineVersion": "5.4.0"` field that was triggering a modal dialog blocking editor startup.

## Test plan

- [x] `compile-all.bat` sweep PASSES on 5.4, 5.4.2_Custom, 5.5, 5.6, and 5.7
- [x] Integration tests on 5.7 pass for files unrelated to test-project content (remaining failures are content-dependent, not from these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)