### PR TITLE
Use base AAIController + event-graph BT wiring

### DIFF
--- a/Source/Arbor/Private/BlueprintBuilder.cpp
+++ b/Source/Arbor/Private/BlueprintBuilder.cpp
@@ -1971,6 +1971,13 @@ UEdGraphNode* UBlueprintBuilder::CreateEventNode(
 	{
 		EventFunc = AActor::StaticClass()->FindFunctionByName(FName(TEXT("ReceiveEndPlay")));
 	}
+	if (!EventFunc && EventName == TEXT("OnPossess"))
+	{
+		// AController exposes the BP-overridable "On Possess" event (display name)
+		// as UFUNCTION(BlueprintImplementableEvent) void ReceivePossess(APawn*).
+		// See Engine/Source/Runtime/Engine/Classes/GameFramework/Controller.h.
+		EventFunc = ParentClass->FindFunctionByName(FName(TEXT("ReceivePossess")));
+	}
 
 	if (!EventFunc)
 	{

--- a/bridge/src/registry/blueprint.ts
+++ b/bridge/src/registry/blueprint.ts
@@ -340,10 +340,30 @@ export const blueprintTool: CategoryTool = {
         name: p.name,
         parent_class: "AIController",
       };
-      const defaults: Record<string, unknown> = {};
-      if (p.behavior_tree_path) defaults.DefaultBehaviorTree = p.behavior_tree_path;
-      if (p.blackboard_path) defaults.DefaultBlackboard = p.blackboard_path;
-      if (Object.keys(defaults).length > 0) bpJson.defaults = defaults;
+
+      // Wire BT auto-run via the event graph: Event OnPossess -> RunBehaviorTree(BTAsset).
+      // Base AAIController has no DefaultBehaviorTree CDO property, so the data-driven
+      // way to run a BT on possess is to override the BP event.
+      // blackboard_path is intentionally not used here — RunBehaviorTree initializes the
+      // blackboard from the BT asset's BlackboardAsset reference.
+      if (p.behavior_tree_path) {
+        bpJson.event_graph = {
+          nodes: [
+            { id: "OnPossess", type: "Event", event: "OnPossess" },
+            {
+              id: "RunBT",
+              type: "CallFunction",
+              function: "RunBehaviorTree",
+              owner_class: "AIController",
+              defaults: { BTAsset: p.behavior_tree_path },
+            },
+          ],
+          connections: [
+            { from: "OnPossess", from_pin: "then", to: "RunBT", to_pin: "execute" },
+          ],
+        };
+      }
+
       if (p.perception_config && (p.perception_config as unknown[]).length > 0) {
         const sensesConfig = (p.perception_config as Array<{sense: string; dominant?: boolean; params?: Record<string, unknown>}>)
           .map(s => ({

--- a/bridge/tests/integration/ai-controller-bt.test.ts
+++ b/bridge/tests/integration/ai-controller-bt.test.ts
@@ -1,15 +1,14 @@
 /**
- * AI Controller + Behavior Tree CDO integration test.
+ * AI Controller + Behavior Tree integration test.
  *
- * Reproduces the bug where a Character BP has AIControllerClass set on its CDO
- * and the AIController BP has DefaultBehaviorTree set on its CDO, but at PIE
- * runtime the BT editor reports "no actor has this BehaviorTree".
+ * Verifies the full chain end-to-end:
+ *   BT → AIController BP (parent: AIController, event graph wires
+ *        OnPossess → RunBehaviorTree(BTAsset)) → Character BP (CDO has
+ *        AIControllerClass + AutoPossessAI) → spawn → PIE → BT is running
  *
- * The test builds the full chain:
- *   BT → AIController BP → Character BP → spawn → PIE → verify BT runs
- *
- * It also inspects CDO values via Python to verify they actually stuck (not
- * just appearing correct in the editor UI).
+ * Also inspects the AIController BP event graph via Python to verify the
+ * Event OnPossess → RunBehaviorTree wiring + the BTAsset pin literal
+ * survived the BlueprintBuilder round-trip.
  */
 
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
@@ -104,10 +103,10 @@ describe.runIf(editorRunning)(
       expect(btPath).toBeDefined();
     });
 
-    // Now uses base AAIController as parent (no AArborAIController exists in C++).
-    // behavior_tree_path/blackboard_path are still passed but base AAIController
-    // has no DefaultBehaviorTree CDO property so they're effectively ignored.
-    it("creates an AIController BP with DefaultBehaviorTree on CDO", async () => {
+    // Parent class is base AAIController. The BT is wired via the BP's event graph
+    // (Event OnPossess → RunBehaviorTree(BTAsset)) — see create_ai_controller in
+    // bridge/src/registry/blueprint.ts.
+    it("creates an AIController BP with BT wired on OnPossess", async () => {
       const name = uniqueName();
       const result = (await blueprintTool.actions.create_ai_controller({
         name,
@@ -135,109 +134,66 @@ describe.runIf(editorRunning)(
 
     // ── Step 2: Inspect CDO values via Python ────────────────────────
 
-    // SKIP: DefaultBehaviorTree is on the imagined AArborAIController; base AAIController has no such CDO property.
-    it.skip("verifies AIController BP parent class is ArborAIController (not plain AIController)", async () => {
-      const data = await pyQuery(`
-import unreal
-
-bp = unreal.EditorAssetLibrary.load_asset("${aicPath}")
-if not bp:
-    _write_result({"success": False, "error": "Could not load AIController BP"})
-else:
-    gen_class = bp.generated_class()
-    # Walk up to the native (non-BP-generated) parent to find what ResolveParentClass picked
-    parent = gen_class.static_class() if gen_class else None
-    parent_name = "None"
-    parent_path = "None"
-    if gen_class:
-        # generated_class().get_name() is e.g. "IntTest_xxx_C"
-        # The CDO's class hierarchy reveals the native parent
-        cdo = unreal.get_default_object(gen_class)
-        cdo_class = cdo.get_class()
-        # Walk up the class chain to find the first non-BlueprintGenerated class
-        current = cdo_class
-        while current:
-            name = current.get_name()
-            if not name.endswith("_C"):
-                parent_name = name
-                parent_path = current.get_path_name()
-                break
-            # Move to super: get the CDO parent's class
-            # In Python API, we can check via unreal.SystemLibrary
-            try:
-                # Use the UClass parent chain via field iteration
-                parent_path_name = current.get_path_name()
-                # Go up: the parent is the native class the BP extends
-                break
-            except:
-                break
-
-        # Simpler approach: check if the CDO has DefaultBehaviorTree property
-        has_bt_prop = hasattr(cdo, "default_behavior_tree")
-        try:
-            cdo.get_editor_property("default_behavior_tree")
-            has_bt_prop = True
-        except:
-            has_bt_prop = False
-
-    _write_result({
-        "success": True,
-        "bp_name": bp.get_name(),
-        "generated_class": gen_class.get_name() if gen_class else "None",
-        "parent_class": parent_name,
-        "parent_path": parent_path,
-        "cdo_has_default_behavior_tree": has_bt_prop,
-    })
-`);
-
-      expect(data.success).toBe(true);
-      // The CDO MUST have the DefaultBehaviorTree property.
-      // This only exists on ArborAIController, not the base AAIController.
-      // If create_ai_controller uses parent_class "AIController" → ResolveParentClass maps to
-      // AAIController → CDO won't have DefaultBehaviorTree → OnPossess won't call RunBehaviorTree.
+    it("verifies AIController BP parent class is AIController", async () => {
+      const q = (await blueprintTool.actions.query({ asset_path: aicPath })) as {
+        success: boolean;
+        parent_class?: string;
+      };
+      expect(q.success).toBe(true);
+      // Parent must be UE's built-in AIController (no custom AArborAIController).
       expect(
-        data.cdo_has_default_behavior_tree,
-        `AIController BP CDO should have DefaultBehaviorTree property (parent should be ` +
-          `ArborAIController, not plain AIController). Parent resolved to: "${data.parent_class}"`
-      ).toBe(true);
+        q.parent_class,
+        `AIController BP parent should be "AIController" but resolved to "${q.parent_class}"`
+      ).toBe("AIController");
     });
 
-    // SKIP: DefaultBehaviorTree is on the imagined AArborAIController; base AAIController has no such CDO property.
-    it.skip("verifies DefaultBehaviorTree is set on AIController CDO", async () => {
-      const data = await pyQuery(`
-import unreal
+    it("verifies AIController BP event graph runs the BT on OnPossess", async () => {
+      type EGNode = {
+        guid: string;
+        type: string;
+        event?: string;
+        function?: string;
+        defaults?: Record<string, string>;
+        pins?: Array<{ name: string; default_object?: string; default?: string }>;
+      };
+      type EGConn = { from: string; from_pin: string; to: string; to_pin: string };
+      const q = (await blueprintTool.actions.query({ asset_path: aicPath })) as {
+        success: boolean;
+        event_graph?: { nodes: EGNode[]; connections: EGConn[] };
+      };
+      expect(q.success).toBe(true);
+      expect(q.event_graph, "AIController BP must have an event graph").toBeDefined();
 
-bp = unreal.EditorAssetLibrary.load_asset("${aicPath}")
-if not bp or not bp.generated_class():
-    _write_result({"success": False, "error": "Could not load AIController BP or no generated class"})
-else:
-    cdo = unreal.get_default_object(bp.generated_class())
-    bt = None
-    bb = None
-    try:
-        bt = cdo.get_editor_property("default_behavior_tree")
-    except:
-        pass
-    try:
-        bb = cdo.get_editor_property("default_blackboard")
-    except:
-        pass
+      const nodes = q.event_graph!.nodes;
+      const conns = q.event_graph!.connections;
 
-    _write_result({
-        "success": True,
-        "cdo_class": cdo.get_class().get_name(),
-        "has_default_bt_property": bt is not None or hasattr(cdo, "default_behavior_tree"),
-        "default_behavior_tree": bt.get_path_name() if bt else None,
-        "default_blackboard": bb.get_path_name() if bb else None,
-    })
-`);
+      const eventNode = nodes.find(
+        (n) => n.type === "Event" && n.event === "ReceivePossess"
+      );
+      const runBTNode = nodes.find(
+        (n) => n.type === "CallFunction" && n.function === "RunBehaviorTree"
+      );
+      expect(eventNode, `expected an Event "ReceivePossess" node; got: ${JSON.stringify(nodes.map(n => ({type: n.type, event: n.event, function: n.function})))}`)
+        .toBeDefined();
+      expect(runBTNode, "expected a CallFunction RunBehaviorTree node").toBeDefined();
 
-      expect(data.success).toBe(true);
-      expect(
-        data.default_behavior_tree,
-        `CDO.DefaultBehaviorTree should be set to "${btPath}" but was ${data.default_behavior_tree}. ` +
-          `If null, SetPropertyFromJson likely couldn't find the property on the base AAIController class.`
-      ).toBeTruthy();
+      const wired = conns.some(
+        (c) =>
+          c.from === eventNode!.guid &&
+          c.from_pin === "then" &&
+          c.to === runBTNode!.guid &&
+          c.to_pin === "execute"
+      );
+      expect(wired, `expected ReceivePossess.then -> RunBehaviorTree.execute connection; got conns: ${JSON.stringify(conns)}`)
+        .toBe(true);
+
+      // BTAsset pin must exist on the RunBehaviorTree call. Verifying the pin's
+      // *value* via this query isn't reliable: the C++ query only exposes
+      // Pin->DefaultValue (string), not Pin->DefaultObject (the asset reference).
+      // The PIE smoke test below is the source of truth for runtime correctness —
+      // a wrong/null BTAsset produces a controller with no BrainComponent.
+      const btPin = runBTNode!.pins?.find((p) => p.name === "BTAsset");
+      expect(btPin, "RunBehaviorTree call should expose a BTAsset pin").toBeDefined();
     });
 
     it("verifies AIControllerClass is set on Character CDO", async () => {
@@ -282,9 +238,7 @@ else:
 
     // ── Step 3: PIE runtime verification ─────────────────────────────
 
-    // SKIP: DefaultBehaviorTree is on the imagined AArborAIController; base AAIController has no such CDO property.
-    // Without auto-RunBehaviorTree on possess, there is no way to wire BT-on-possess through pure data.
-    it.skip(
+    it(
       "spawns the character, starts PIE, and verifies BT is running",
       async () => {
         // Place the character in the level


### PR DESCRIPTION
## Summary

Replaces the `create_ai_controller` design that quietly assumed a custom `AArborAIController` C++ class (which doesn't exist in `Source/Arbor/`) with one that uses UE's built-in `AAIController` plus an event-graph wiring pattern.

The previous design passed `defaults.DefaultBehaviorTree` / `DefaultBlackboard` to the BlueprintBuilder, but base `AAIController` has no such CDO properties — `ApplyClassDefaults` silently skipped them, leaving the AIController BP with no way to actually run its BT on possess.

## What changed

**`Source/Arbor/Private/BlueprintBuilder.cpp`** — extend the event-name fallback table next to the existing `BeginPlay` / `Tick` / `EndPlay` mappings so that an event named `"OnPossess"` resolves to `ReceivePossess` on the parent class. That's the actual `UFUNCTION(BlueprintImplementableEvent, meta=(DisplayName="On Possess"))` declared on `AController` (`Engine/Source/Runtime/Engine/Classes/GameFramework/Controller.h:289-290`).

**`bridge/src/registry/blueprint.ts`** — when `behavior_tree_path` is provided, build an `event_graph` section with `Event OnPossess → RunBehaviorTree(BTAsset)` instead of writing to non-existent CDO properties. Drop the now-useless `blackboard_path` application — `RunBehaviorTree(UBehaviorTree*)` initializes the blackboard from the BT asset's `BlackboardAsset` reference.

**`bridge/tests/integration/ai-controller-bt.test.ts`** — un-skip the three tests that PR #16 marked as aspirational. Replace the `DefaultBehaviorTree` CDO probe with an event-graph probe that uses the bridge's own `query` action to confirm `Event ReceivePossess.then` is wired to `RunBehaviorTree.execute`. The PIE smoke test stays as the runtime source of truth — a wrong/null `BTAsset` produces a controller with no `BrainComponent`, which the smoke test catches end-to-end.

## Test plan

- [x] `npx vitest run tests/integration/ai-controller-bt.test.ts` — 7 passed, 0 failed (was 3 skipped before)
- [x] Full integration sweep on UE 5.7 — 257 passed / 45 skipped / 0 failed (3 fewer skips than the post-PR-#16 baseline of 254/48)
- [ ] Open one of the test-suite-created AIController BPs in the editor, confirm parent class is `AIController` and the event graph shows `Event On Possess → Run Behavior Tree`

🤖 Generated with [Claude Code](https://claude.com/claude-code)