### PR TITLE
Add Claude-driven e2e test harness for the MCP bridge

### DIFF
--- a/.claude/skills/run-tests.md
+++ b/.claude/skills/run-tests.md
@@ -1,0 +1,94 @@
+---
+name: run-tests
+description: Use to run Arbor's test suites — bridge integration tests, single-engine e2e, the bridge TypeScript build, or the multi-engine compile + e2e sweep. Supports running one suite or all in sequence. Triggers: "run tests", "run all tests", "test arbor", "compile across versions", "run integration", "run e2e", "tiny arena", "build the bridge". Skip for: writing new tests (use the test files directly), debugging a single failing test (run vitest with `--reporter=verbose` directly).
+---
+
+# Running Arbor Tests
+
+Arbor ships four test/build surfaces. Pick one or run them in sequence. **Default to confirming with the user before running the multi-engine sweep — it takes ~45 min and costs ~$10 in Claude API credits.**
+
+## Test surfaces
+
+| Suite | What it covers | Command |
+|---|---|---|
+| `build` | Bridge TypeScript compiles cleanly | `npm run build` in `<bridge>` |
+| `integration` | Bridge MCP actions hit a live editor | `npm test` in `<bridge>` |
+| `e2e` | Claude builds a scenario from a prompt; validators check the result against the *currently running* editor | `npm run test:e2e` in `<bridge>` (with `RUN_CLAUDE_E2E=1` in env) |
+| `sweep` | Per-version compile + boot + e2e for each engine in the rig | `$env:ARBOR_RIG_SCRIPT` (see "Multi-engine rig" below) |
+
+**Note on "unit tests":** Arbor doesn't ship a dedicated unit-test suite — `tests/integration/` is the lowest layer. If the user asks for "unit tests", clarify whether they mean integration. (For UE5 *automation* tests in their own game, point them at `arbor.automation.run_tests()` per the Arbor CLAUDE.md — that's their game's tests, not Arbor's.)
+
+## Configurable paths
+
+The skill never hardcodes paths. Resolve in this order:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `ARBOR_BRIDGE_DIR` | first match of `./bridge`, `./Plugins/Arbor/bridge`, then walk up looking for an `Arbor.uplugin` sibling and use `<arbor-root>/bridge` | Where the bridge npm scripts run from |
+| `ARBOR_TEST_RIG` | *unset* | Directory containing one `Test_<version>/` subfolder per UE engine to test |
+| `ARBOR_RIG_SCRIPT` | `$ARBOR_TEST_RIG/run-e2e-all.ps1` | The orchestrator script in the rig |
+
+If any required var is unset for the requested suite, **stop and ask the user** — don't guess a path.
+
+## Preconditions
+
+- **build**: only requires Node + the bridge's `node_modules`. If `node_modules` is missing, `npm ci` first.
+- **integration**: UE5 editor running with an Arbor-enabled project loaded; Remote Control responding (default port 30010, override via `UE5_REMOTE_PORT`). Tests skip cleanly if editor unreachable.
+- **e2e**: same as integration, plus `RUN_CLAUDE_E2E=1` and the `claude` CLI on `PATH`.
+- **sweep**: the rig (next section). The orchestrator spawns its own editors per project.
+
+Ping first if you're unsure: `mcp__ue5-bridge__ue5_ping`.
+
+## Multi-engine rig
+
+The orchestrator script lives outside the Arbor repo because it depends on local engine installs and project layout choices. The convention this skill expects:
+
+- `$ARBOR_TEST_RIG` points at a directory containing `Test_<version>/<Project>.uproject` folders (one per UE version, e.g. `Test_5.4/TP_Blank.uproject`, `Test_5.5/TP_Blank.uproject`).
+- Each `Test_<version>/Plugins/Arbor` is an NTFS junction → the canonical Arbor plugin source so all engines share one source tree. (Only one engine's `Binaries/` can sit there at a time — the orchestrator handles the per-version rebuild.)
+- The orchestrator (`run-e2e-all.ps1` by default) iterates `Test_*/`, recompiles Arbor for each engine, launches UE5, sets `ARBOR_E2E_PROJECT=<name>` so reports are tagged per project, and runs the e2e suite.
+
+If `$env:ARBOR_TEST_RIG` isn't set when the user asks for a sweep:
+
+1. Explain the convention above.
+2. Offer to point at an existing rig if they have one.
+3. Don't fabricate or auto-create a rig.
+
+## Sequencing for "all"
+
+When the user says "all tests" without qualification:
+
+1. `build` (bridge TS compile — fast, fails loud).
+2. `integration` (vitest — assumes editor is up).
+3. **Pause and confirm** before `sweep` because of cost/duration. Skip if they say no.
+
+Stop on first failure — there's no point running e2e when integration is red, or sweep when integration is red, etc.
+
+If they say "all but skip sweep" or "all except e2e", honour it. If they say "everything including sweep", proceed without confirmation.
+
+## Running one
+
+| User says | Do |
+|---|---|
+| "build the bridge", "tsc", "compile the bridge" | `npm run build` in `$ARBOR_BRIDGE_DIR` |
+| "run tests" (no qualifier), "integration", "vitest", "bridge tests" | `npm test` in `$ARBOR_BRIDGE_DIR` |
+| "run e2e", "tiny arena", "claude e2e" | `npm run test:e2e` in `$ARBOR_BRIDGE_DIR` with `RUN_CLAUDE_E2E=1`. Verify editor first; if down, ask. |
+| "run sweep", "across versions", "all engines" | `$ARBOR_RIG_SCRIPT` — confirm first. |
+| "test 5.7" or "only 5.7" | `$ARBOR_RIG_SCRIPT -Only Test_5.7` |
+| "sweep, skip rebuild" | `$ARBOR_RIG_SCRIPT -SkipBuild` |
+
+## Reporting results
+
+After each suite, summarize in 1–2 sentences. Reuse the suite's own counters — don't recount.
+
+- **build**: success / first error.
+- **integration**: pass/fail counts.
+- **e2e**: pass/fail count *and* the report HTML path (`bridge/tests/e2e/.results/<dir>/report.html`).
+- **sweep**: the per-project table the orchestrator already prints. Don't reformat it.
+
+Don't paste raw vitest output back to the user — they'll read the file if they want details.
+
+## When NOT to use this skill
+
+- Authoring or fixing a single test → invoke `vitest run <file> --reporter=verbose` directly.
+- Diagnosing a known failure → read the existing `bridge/tests/e2e/.results/<latest>/report.html` or test output before re-running.
+- Inside CI → there's no CI for Arbor yet; this skill is for ad-hoc local runs.

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ Build/
 Intermediate/
 Saved/
 .vs/
-.claude/
+# Ignore everything inside .claude/ except shipped skills.
+# Excluding the dir itself (`.claude/`) would block re-inclusion below —
+# git can't unignore children of an ignored parent.
+.claude/*
+!.claude/skills/
 *.sln
 *.suo
 
@@ -21,6 +25,7 @@ bridge/dist/
 bridge/.env
 bridge/.env.local
 bridge/*.log
+bridge/tests/e2e/.results/
 
 # Local MCP config (contains secrets)
 .mcp.json

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -15,7 +15,8 @@
     "start": "node dist/index.js",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "vitest run tests/e2e"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",

--- a/bridge/tests/e2e/README.md
+++ b/bridge/tests/e2e/README.md
@@ -1,0 +1,118 @@
+# Arbor E2E — Claude-driven scenario tests
+
+Tests under this folder put **Claude in the loop**: each scenario hands the
+Claude Code CLI a high-level natural-language prompt, lets it drive the MCP
+tool surface to build something in UE5, then runs assertion queries against
+the live editor and writes a JSON + HTML report.
+
+This is different from `tests/integration/` — those tests call MCP action
+handlers directly with hardcoded args. The integration suite verifies the
+*tools* work; the e2e suite verifies that *Claude can use* the tools.
+
+## When to run
+
+- After a meaningful change to the bridge or to the C++ Arbor tools, to
+  confirm the public surface still composes end-to-end through Claude.
+- Before publishing a new bridge version.
+
+Not on every `npm test` — Claude spawns cost API credits and the test takes
+several minutes.
+
+## Requirements
+
+1. UE5 editor running with the project loaded and the Remote Control API
+   enabled (same as `tests/integration/`).
+2. `claude` (Claude Code CLI) on `PATH` and signed in.
+3. `npm run build` already executed in `bridge/` so `dist/index.js` exists —
+   the spawned Claude reads the bridge from there.
+
+## Running
+
+The e2e tests are gated behind `RUN_CLAUDE_E2E=1` so they don't fire on a
+plain `npm test`:
+
+```sh
+# bash
+RUN_CLAUDE_E2E=1 npx vitest run tests/e2e
+
+# Windows cmd
+set RUN_CLAUDE_E2E=1 && npx vitest run tests/e2e
+
+# PowerShell
+$env:RUN_CLAUDE_E2E="1"; npx vitest run tests/e2e
+```
+
+When the test finishes (pass or fail) it prints a path to a self-contained
+HTML report in `tests/e2e/.results/<scenario>-<iso>/report.html`. Open it
+in a browser to see per-requirement pass/fail, embedded screenshots, and the
+tail of Claude's stdout/stderr.
+
+## Adding a scenario
+
+A scenario is one file under `scenarios/<name>.ts` that exports a `Scenario`
+object. Then add a sibling `<name>.e2e.test.ts` that wires it into Vitest.
+
+```ts
+// scenarios/my-scene.ts
+import type { Scenario } from "../helpers/requirement.js";
+import { actorWithLabelExists, /* ... */ } from "../helpers/validators.js";
+
+export const myScene: Scenario = {
+  id: "my-scene",
+  name: "My Scene",
+  assetCleanupRoot: "/Game/E2E",
+  actorPrefix: "E2E_MyScene_",
+  prompt: `Build ... Use ue5_* tools. Don't ask for input. Use these labels: ...`,
+  requirements: [
+    { id: "...", name: "...", category: "actors", check: () => actorWithLabelExists("E2E_MyScene_Foo") },
+    // ...
+  ],
+};
+```
+
+```ts
+// my-scene.e2e.test.ts — copy tiny-arena.e2e.test.ts and swap the import.
+```
+
+### Writing prompts
+
+- **Pin down labels and asset paths** that validators will look for. The point
+  of an e2e test is that Claude composes the *tools*, not that it picks names.
+- **Forbid playtest** unless validating PIE-driven behavior — PIE input causes
+  flakes.
+- **Confine cleanup scope**: tell Claude not to touch anything outside
+  `assetCleanupRoot` or actors without `actorPrefix`. Cleanup hooks rely on
+  these prefixes.
+- **One-shot**: tell Claude not to ask the user for input and not to pause —
+  the runner is non-interactive.
+
+### Writing requirements
+
+- Reuse primitives in `helpers/validators.ts` first; add new ones only when
+  none of them fit.
+- Each `check()` returns `{ passed, detail, observed }`. `observed` shows up
+  in the HTML report under an expandable "observed" block, so make it useful
+  for triage when a requirement fails.
+- Validators are read-only — they query the editor via MCP `*_query` actions
+  or `ue5_run_python` introspection. Never mutate the level inside a check.
+
+## File layout
+
+```
+tests/e2e/
+├── helpers/
+│   ├── requirement.ts    # Scenario / Requirement types
+│   ├── validators.ts     # Reusable assertion primitives
+│   └── cleanup.ts        # Per-prefix actor + asset cleanup
+├── runner/
+│   ├── mcp-config.ts     # Writes a temp .mcp.json for the spawned Claude
+│   ├── claude-runner.ts  # Spawns `claude --print` with the bridge attached
+│   └── report-writer.ts  # JSON + self-contained HTML report
+├── scenarios/
+│   └── tiny-arena.ts     # First scenario
+├── tiny-arena.e2e.test.ts
+├── .results/             # Output (gitignored — see below)
+└── README.md
+```
+
+`.results/` is local-only — add it to your `.gitignore` if it isn't already.

--- a/bridge/tests/e2e/helpers/cleanup.ts
+++ b/bridge/tests/e2e/helpers/cleanup.ts
@@ -1,0 +1,76 @@
+/**
+ * E2E-scoped cleanup helpers. Mirror `tests/helpers/level-isolation.ts` and
+ * `tests/helpers/asset-cleanup.ts` but parameterized so each scenario can use
+ * its own prefix without modifying the shared helpers (which the integration
+ * suite depends on with their hardcoded "IntTest_" / "IntTest" values).
+ */
+
+import { callArborJson } from "../../../src/ue5-client.js";
+import { runPython } from "../../../src/tools/core/run-python.js";
+
+export async function clearActorsByPrefix(prefix: string): Promise<void> {
+  try {
+    const scene = (await callArborJson("ArborActorTools", "GetSceneInfo", {
+      FilterClass: "",
+      FilterPrefix: prefix,
+    })) as { actors?: Array<{ name: string; label: string }> };
+
+    if (scene.actors && scene.actors.length > 0) {
+      const names = scene.actors.map((a) => a.label || a.name);
+      await callArborJson("ArborActorTools", "DeleteActors", {
+        ActorNamesJson: JSON.stringify(names),
+      });
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Delete a content subtree (e.g. "/Game/E2E"). Uses the same retry+GC dance as
+ * `asset-cleanup.ts` because UE5 holds file handles on loaded assets.
+ */
+export async function deleteAssetsUnder(contentSubdir: string): Promise<void> {
+  const subdir = contentSubdir.replace(/^\/Game\/?/, "").replace(/\/$/, "");
+  if (!subdir) return;
+  try {
+    await runPython({
+      code: `
+import unreal
+import os
+import shutil
+import time
+
+content_dir = unreal.Paths.project_content_dir()
+target_dir = os.path.normpath(os.path.join(content_dir, ${JSON.stringify(subdir)}))
+
+if not os.path.isdir(target_dir):
+    _write_result({"success": True, "note": "directory did not exist"})
+else:
+    file_count_before = sum(len(files) for _, _, files in os.walk(target_dir))
+    for _ in range(5):
+        unreal.SystemLibrary.collect_garbage()
+
+    deleted = False
+    remaining = file_count_before
+    for _ in range(5):
+        shutil.rmtree(target_dir, ignore_errors=True)
+        if not os.path.isdir(target_dir):
+            deleted = True
+            remaining = 0
+            break
+        remaining = sum(len(files) for _, _, files in os.walk(target_dir))
+        time.sleep(0.5)
+        unreal.SystemLibrary.collect_garbage()
+
+    _write_result({
+        "success": deleted,
+        "files_before": file_count_before,
+        "files_remaining": remaining,
+    })
+`,
+    });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/bridge/tests/e2e/helpers/requirement.ts
+++ b/bridge/tests/e2e/helpers/requirement.ts
@@ -1,0 +1,38 @@
+/**
+ * Types for declarative E2E scenarios.
+ *
+ * A Scenario is a single high-level prompt handed to Claude plus a list of
+ * Requirements. After Claude runs, every requirement's `check` is invoked
+ * against the live UE5 editor. The results land in the report.
+ */
+
+export interface RequirementResult {
+  passed: boolean;
+  /** Short human-readable line — what was checked. */
+  detail: string;
+  /** Raw observed value (object/array/scalar) for the report. */
+  observed?: unknown;
+}
+
+export interface Requirement {
+  /** Stable id used in JSON; should be a short slug. */
+  id: string;
+  /** Display name in the report. */
+  name: string;
+  /** The MCP category this requirement exercises (e.g. "actors", "ai"). */
+  category: string;
+  check(): Promise<RequirementResult>;
+}
+
+export interface Scenario {
+  id: string;
+  /** Human-readable scenario title for the report. */
+  name: string;
+  /** Prompt verbatim — handed to `claude -p`. */
+  prompt: string;
+  /** Asset path prefix to clean up after the run (e.g. "/Game/E2E"). */
+  assetCleanupRoot: string;
+  /** Actor label prefix to clean up after the run (e.g. "E2E_TinyArena_"). */
+  actorPrefix: string;
+  requirements: Requirement[];
+}

--- a/bridge/tests/e2e/helpers/validators.ts
+++ b/bridge/tests/e2e/helpers/validators.ts
@@ -1,0 +1,549 @@
+/**
+ * Reusable validator primitives. Each returns a RequirementResult with both a
+ * boolean pass and the raw observed value, so the report can show what was
+ * actually found when a requirement fails.
+ *
+ * Validators only call read-only MCP actions + Python introspection — they
+ * never mutate the level. If a validator needs to look at an asset on disk
+ * (screenshots), it does so without touching the editor.
+ */
+
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import { actorsTool } from "../../../src/registry/actors.js";
+import { aiTool } from "../../../src/registry/ai.js";
+import { blueprintTool } from "../../../src/registry/blueprint.js";
+import { runPython } from "../../../src/tools/core/run-python.js";
+import type { RequirementResult } from "./requirement.js";
+
+interface SceneActor {
+  name: string;
+  label: string;
+  class: string;
+  location?: { x: number; y: number; z: number };
+}
+
+interface SceneInfo {
+  actors?: SceneActor[];
+}
+
+async function sceneActors(prefix?: string, klass?: string): Promise<SceneActor[]> {
+  const result = (await actorsTool.actions.scene_info({
+    filter_prefix: prefix,
+    filter_class: klass,
+  })) as SceneInfo;
+  return result.actors ?? [];
+}
+
+// ─── Actor / scene validators ──────────────────────────────────────────
+
+export async function actorWithLabelExists(
+  labelStartsWith: string
+): Promise<RequirementResult> {
+  const actors = await sceneActors(labelStartsWith);
+  const matches = actors.filter((a) =>
+    (a.label || a.name).startsWith(labelStartsWith)
+  );
+  return {
+    passed: matches.length > 0,
+    detail: `expected ≥1 actor with label starting "${labelStartsWith}", found ${matches.length}`,
+    observed: matches.map((a) => ({
+      label: a.label || a.name,
+      class: a.class,
+    })),
+  };
+}
+
+export async function countActorsWithLabel(
+  labelStartsWith: string,
+  expectedAtLeast: number
+): Promise<RequirementResult> {
+  const actors = await sceneActors(labelStartsWith);
+  const matches = actors.filter((a) =>
+    (a.label || a.name).startsWith(labelStartsWith)
+  );
+  return {
+    passed: matches.length >= expectedAtLeast,
+    detail: `expected ≥${expectedAtLeast} actors with label starting "${labelStartsWith}", found ${matches.length}`,
+    observed: matches.map((a) => a.label || a.name),
+  };
+}
+
+export async function actorOfClassExists(
+  className: string,
+  prefix?: string
+): Promise<RequirementResult> {
+  const actors = await sceneActors(prefix, className);
+  return {
+    passed: actors.length > 0,
+    detail: `expected ≥1 actor of class "${className}"${prefix ? ` with prefix "${prefix}"` : ""}, found ${actors.length}`,
+    observed: actors.map((a) => ({ label: a.label || a.name, class: a.class })),
+  };
+}
+
+/**
+ * Outdoor lighting check — UE adds a Directional Light + sky atmosphere/skylight
+ * when `arbor.lighting.setup_outdoor_scene()` runs. We only require that ≥1
+ * directional light is present (the sky setup varies with engine version).
+ */
+export async function outdoorLightingPresent(): Promise<RequirementResult> {
+  const directional = await sceneActors(undefined, "DirectionalLight");
+  const skyAtmo = await sceneActors(undefined, "SkyAtmosphere");
+  const skyLight = await sceneActors(undefined, "SkyLight");
+  const passed =
+    directional.length > 0 && (skyAtmo.length > 0 || skyLight.length > 0);
+  return {
+    passed,
+    detail: `expected DirectionalLight + (SkyAtmosphere or SkyLight); got dir=${directional.length} skyAtmo=${skyAtmo.length} skyLight=${skyLight.length}`,
+    observed: { directional: directional.length, skyAtmo: skyAtmo.length, skyLight: skyLight.length },
+  };
+}
+
+// ─── Material distinctness ─────────────────────────────────────────────
+
+/**
+ * Compare the assigned override material on a wall actor to the floor's. If
+ * either has no override (engine default), or both share the same material
+ * path, fail.
+ */
+export async function wallAndFloorMaterialsDiffer(
+  floorLabelPrefix: string,
+  wallLabelPrefix: string
+): Promise<RequirementResult> {
+  const data = await pyJson(`
+import unreal
+
+def primary_material_path(actor):
+    """Return the path of the first material on the first SMC, override or asset."""
+    smc = actor.get_component_by_class(unreal.StaticMeshComponent)
+    if not smc:
+        return None
+    # Override first
+    overrides = smc.get_editor_property("override_materials") or []
+    for m in overrides:
+        if m:
+            return m.get_path_name()
+    # Fall back to material set on the mesh asset
+    mesh = smc.get_editor_property("static_mesh")
+    if mesh:
+        mats = mesh.get_editor_property("static_materials") or []
+        for entry in mats:
+            mi = entry.material_interface if hasattr(entry, "material_interface") else None
+            if mi:
+                return mi.get_path_name()
+    return None
+
+ess = unreal.get_editor_subsystem(unreal.UnrealEditorSubsystem)
+world = ess.get_editor_world() if ess else None
+all_actors = unreal.GameplayStatics.get_all_actors_of_class(world, unreal.Actor) if world else []
+
+floor_mat = None
+wall_mats = []
+for a in all_actors:
+    label = a.get_actor_label()
+    if label.startswith(${JSON.stringify(floorLabelPrefix)}):
+        floor_mat = primary_material_path(a)
+    elif label.startswith(${JSON.stringify(wallLabelPrefix)}):
+        m = primary_material_path(a)
+        if m:
+            wall_mats.append(m)
+
+distinct = floor_mat is not None and any(m != floor_mat for m in wall_mats)
+_write_result({
+    "floor_material": floor_mat,
+    "wall_materials": wall_mats,
+    "distinct": distinct,
+})
+`);
+  return {
+    passed: data.distinct === true,
+    detail: data.distinct
+      ? `wall material differs from floor material`
+      : `walls and floor share the same material (or one has no material)`,
+    observed: data,
+  };
+}
+
+// ─── Asset / Blueprint validators ──────────────────────────────────────
+
+export async function blueprintAtPath(
+  assetPath: string
+): Promise<RequirementResult> {
+  try {
+    const result = (await blueprintTool.actions.query({
+      asset_path: assetPath,
+    })) as { success?: boolean; asset_path?: string; error?: string };
+    const passed = result.success !== false && !result.error;
+    return {
+      passed,
+      detail: passed
+        ? `Blueprint found at ${assetPath}`
+        : `Blueprint not found at ${assetPath}: ${result.error ?? "unknown error"}`,
+      observed: result,
+    };
+  } catch (e) {
+    return {
+      passed: false,
+      detail: `query() threw for ${assetPath}: ${(e as Error).message}`,
+      observed: { error: (e as Error).message },
+    };
+  }
+}
+
+/**
+ * The character BP CDO should have an AIControllerClass set, which transitively
+ * carries the BehaviorTree (set on the AIController BP CDO). We accept either
+ * an AIController-only chain or a directly-set DefaultBehaviorTree.
+ */
+export async function characterBpHasAiControllerWired(
+  charPath: string
+): Promise<RequirementResult> {
+  const data = await pyJson(`
+import unreal
+
+bp = unreal.EditorAssetLibrary.load_asset(${JSON.stringify(charPath)})
+if not bp or not bp.generated_class():
+    _write_result({"loaded": False})
+else:
+    cdo = unreal.get_default_object(bp.generated_class())
+    aic = cdo.get_editor_property("ai_controller_class")
+    aic_path = aic.get_path_name() if aic else None
+    bt_path = None
+    if aic:
+        try:
+            aic_cdo = unreal.get_default_object(aic)
+            bt = aic_cdo.get_editor_property("default_behavior_tree")
+            bt_path = bt.get_path_name() if bt else None
+        except Exception:
+            pass
+    _write_result({
+        "loaded": True,
+        "ai_controller_class": aic_path,
+        "default_behavior_tree": bt_path,
+    })
+`);
+  const passed = data.loaded === true && !!data.ai_controller_class;
+  return {
+    passed,
+    detail: passed
+      ? `Character BP has AIControllerClass=${data.ai_controller_class}, BT=${data.default_behavior_tree ?? "(none on AIC)"}`
+      : `Character BP missing AIControllerClass`,
+    observed: data,
+  };
+}
+
+/** Walk a behavior tree's structure (via aiTool.query_bt) looking for a node class match. */
+export async function behaviorTreeContainsNodeClass(
+  btPath: string,
+  nodeClassSubstring: string
+): Promise<RequirementResult> {
+  try {
+    const result = (await aiTool.actions.query_bt({
+      asset_path: btPath,
+    })) as Record<string, unknown>;
+    const json = JSON.stringify(result);
+    const passed = json.includes(nodeClassSubstring);
+    return {
+      passed,
+      detail: passed
+        ? `BT at ${btPath} contains node matching "${nodeClassSubstring}"`
+        : `BT at ${btPath} has no node matching "${nodeClassSubstring}"`,
+      observed: result,
+    };
+  } catch (e) {
+    return {
+      passed: false,
+      detail: `query_bt() threw for ${btPath}: ${(e as Error).message}`,
+      observed: { error: (e as Error).message },
+    };
+  }
+}
+
+/**
+ * Resolve the BehaviorTree associated with a Character BP. Tries three paths
+ * in order, since Arbor's canonical "wire BT on AIController" pattern uses
+ * an event-graph `RunBehaviorTree` call rather than a CDO property
+ * (stock `AAIController` doesn't expose `default_behavior_tree`):
+ *   1. `default_behavior_tree` on the AIController CDO (custom subclasses).
+ *   2. Walk the AIController BP's event graphs for a `RunBehaviorTree` call
+ *      and read the `BTAsset` pin literal.
+ *   3. If `fallbackSearchRoot` is given, scan that folder for BehaviorTree
+ *      assets; if exactly one exists, take it.
+ *
+ * Returns the BT asset path or null if no path resolves.
+ */
+export async function behaviorTreePathFromCharacter(
+  charPath: string,
+  fallbackSearchRoot?: string
+): Promise<string | null> {
+  const data = await pyJson(`
+import unreal
+
+CHAR_PATH = ${JSON.stringify(charPath)}
+FALLBACK_ROOT = ${JSON.stringify(fallbackSearchRoot ?? "")}
+
+bt_path = None
+resolved_via = None
+debug = {"checked_aic_path": None, "ubergraph_count": 0, "callfunc_count": 0,
+         "found_run_bt_call": False, "fallback_candidates": []}
+
+bp = unreal.EditorAssetLibrary.load_asset(CHAR_PATH)
+if bp and bp.generated_class():
+    cdo = unreal.get_default_object(bp.generated_class())
+    aic = cdo.get_editor_property("ai_controller_class")
+    if aic:
+        debug["checked_aic_path"] = aic.get_path_name()
+        # 1. CDO property (only present on custom AIController subclasses)
+        try:
+            aic_cdo = unreal.get_default_object(aic)
+            bt = aic_cdo.get_editor_property("default_behavior_tree")
+            if bt:
+                bt_path = bt.get_path_name()
+                resolved_via = "cdo_default_behavior_tree"
+        except Exception:
+            pass
+
+        # 2. AIController BP event-graph: K2Node_CallFunction "RunBehaviorTree"
+        if not bt_path:
+            # generated_class has a "_C" suffix — strip to load the BP asset
+            aic_class_path = aic.get_path_name()
+            if aic_class_path.endswith("_C"):
+                aic_bp_path = aic_class_path[:-2]
+            else:
+                aic_bp_path = aic_class_path
+            aic_bp = unreal.EditorAssetLibrary.load_asset(aic_bp_path)
+            if aic_bp:
+                try:
+                    pages = aic_bp.get_editor_property("ubergraph_pages") or []
+                    debug["ubergraph_count"] = len(pages)
+                    for graph in pages:
+                        nodes = graph.get_editor_property("nodes") or []
+                        for node in nodes:
+                            if node.get_class().get_name() != "K2Node_CallFunction":
+                                continue
+                            debug["callfunc_count"] += 1
+                            ref = node.get_editor_property("function_reference")
+                            mname = str(ref.get_member_name())
+                            if mname != "RunBehaviorTree":
+                                continue
+                            debug["found_run_bt_call"] = True
+                            for pin in (node.get_editor_property("pins") or []):
+                                if str(pin.get_editor_property("pin_name")) != "BTAsset":
+                                    continue
+                                # Object literals are stored on default_object;
+                                # if the pin is wired, follow the link to a literal
+                                d = pin.get_editor_property("default_object")
+                                if d:
+                                    bt_path = d.get_path_name()
+                                    resolved_via = "event_graph_default_object"
+                                    break
+                                links = pin.get_editor_property("linked_to") or []
+                                for linked in links:
+                                    owner = linked.get_editor_property("owning_node")
+                                    if owner and owner.get_class().get_name() in (
+                                        "K2Node_Literal", "K2Node_Self"
+                                    ):
+                                        try:
+                                            lit_obj = owner.get_editor_property("object_ref")
+                                            if lit_obj:
+                                                bt_path = lit_obj.get_path_name()
+                                                resolved_via = "event_graph_literal_node"
+                                                break
+                                        except Exception:
+                                            pass
+                            if bt_path:
+                                break
+                        if bt_path:
+                            break
+                except Exception as e:
+                    debug["walker_error"] = str(e)
+
+# 3. Folder scan fallback — only applied when caller passed a root
+if not bt_path and FALLBACK_ROOT:
+    try:
+        ar = unreal.AssetRegistryHelpers.get_asset_registry()
+        assets = ar.get_assets_by_path(FALLBACK_ROOT, recursive=True)
+        for a in assets:
+            cls = str(a.asset_class_path.asset_name) if hasattr(a, "asset_class_path") else str(a.asset_class)
+            if cls == "BehaviorTree":
+                debug["fallback_candidates"].append(str(a.package_name))
+        if len(debug["fallback_candidates"]) == 1:
+            bt_path = debug["fallback_candidates"][0]
+            resolved_via = "fallback_single_bt_in_folder"
+    except Exception as e:
+        debug["fallback_error"] = str(e)
+
+_write_result({"bt_path": bt_path, "resolved_via": resolved_via, "debug": debug})
+`);
+  return (data.bt_path as string | null) ?? null;
+}
+
+// ─── Screenshot validation ─────────────────────────────────────────────
+
+/**
+ * Find the most recently modified PNG/JPG inside the project's Saved/Screenshots
+ * tree that's newer than `sinceMs`. Walks the tree shallowly (UE puts shots in
+ * Saved/Screenshots/<Platform>/).
+ */
+export async function findLatestScreenshotSince(
+  sinceMs: number
+): Promise<string | null> {
+  const data = await pyJson(`
+import unreal
+import os
+
+# Search both the engine default (Saved/Screenshots/) and arbor.capture's
+# subdir (Saved/Arbor/Screenshots/) — different tools write to different roots.
+saved = unreal.Paths.project_saved_dir()
+roots = [
+    os.path.normpath(os.path.join(saved, "Screenshots")),
+    os.path.normpath(os.path.join(saved, "Arbor", "Screenshots")),
+]
+latest = None
+latest_mtime = 0
+for root_dir in roots:
+    if not os.path.isdir(root_dir):
+        continue
+    for root, _dirs, files in os.walk(root_dir):
+        for f in files:
+            if not (f.lower().endswith(".png") or f.lower().endswith(".jpg") or f.lower().endswith(".jpeg")):
+                continue
+            full = os.path.join(root, f)
+            try:
+                mt = os.path.getmtime(full)
+            except OSError:
+                continue
+            if mt > latest_mtime and mt * 1000 >= ${sinceMs - 2000}:
+                latest_mtime = mt
+                latest = full
+
+_write_result({"path": latest, "mtime_ms": int(latest_mtime * 1000)})
+`);
+  return (data.path as string | null) ?? null;
+}
+
+/**
+ * Return *all* PNG/JPG files in the project's Saved/Screenshots tree that are
+ * newer than `sinceMs`. Used by the test to collect every screenshot Claude
+ * took during the run for the HTML report.
+ */
+export async function findAllScreenshotsSince(
+  sinceMs: number
+): Promise<string[]> {
+  const data = await pyJson(`
+import unreal
+import os
+
+saved = unreal.Paths.project_saved_dir()
+roots = [
+    os.path.normpath(os.path.join(saved, "Screenshots")),
+    os.path.normpath(os.path.join(saved, "Arbor", "Screenshots")),
+]
+matches = []
+for root_dir in roots:
+    if not os.path.isdir(root_dir):
+        continue
+    for root, _dirs, files in os.walk(root_dir):
+        for f in files:
+            if not (f.lower().endswith(".png") or f.lower().endswith(".jpg") or f.lower().endswith(".jpeg")):
+                continue
+            full = os.path.join(root, f)
+            try:
+                mt = os.path.getmtime(full)
+            except OSError:
+                continue
+            if mt * 1000 >= ${sinceMs - 2000}:
+                matches.append({"path": full, "mtime_ms": int(mt * 1000)})
+
+matches.sort(key=lambda m: m["mtime_ms"])
+_write_result({"shots": matches})
+`);
+  const shots = (data.shots as Array<{ path: string }>) ?? [];
+  return shots.map((s) => s.path);
+}
+
+/**
+ * Validate that a screenshot exists on disk and has reasonable mean pixel
+ * brightness (i.e. it's not pitch black, which is what we get if the orbit
+ * camera ended up inside a wall or PIE failed). No image-decoding deps —
+ * we sample the file's raw bytes instead, which is a coarse but adequate
+ * "did the editor render anything" signal for PNG/JPG.
+ */
+export async function screenshotIsNotBlank(
+  path: string | null
+): Promise<RequirementResult> {
+  if (!path) {
+    return { passed: false, detail: "no screenshot path provided", observed: null };
+  }
+  try {
+    const stat = await fs.stat(path);
+    if (stat.size < 1024) {
+      return {
+        passed: false,
+        detail: `screenshot file is suspiciously small (${stat.size} bytes)`,
+        observed: { path, size: stat.size },
+      };
+    }
+    // Sample raw bytes — files of pure black render to large runs of zero/0xFF
+    // padded chunks once compressed, but real renders have wide byte variance.
+    // Read up to 256 KB and compute byte-value variance as a cheap proxy.
+    const buf = await fs.readFile(path);
+    const sample = buf.subarray(0, Math.min(buf.length, 262144));
+    let sum = 0;
+    let sumSq = 0;
+    for (let i = 0; i < sample.length; i++) {
+      sum += sample[i]!;
+      sumSq += sample[i]! * sample[i]!;
+    }
+    const mean = sum / sample.length;
+    const variance = sumSq / sample.length - mean * mean;
+    // Empirically, a black PNG has variance < 200; a real render has > 2000.
+    const passed = variance > 1000;
+    return {
+      passed,
+      detail: passed
+        ? `screenshot at ${path} (${stat.size} bytes, byte-variance ${variance.toFixed(0)})`
+        : `screenshot looks blank — byte-variance ${variance.toFixed(0)} below threshold`,
+      observed: { path, size: stat.size, byte_variance: Math.round(variance) },
+    };
+  } catch (e) {
+    return {
+      passed: false,
+      detail: `screenshot path unreadable: ${(e as Error).message}`,
+      observed: { path, error: (e as Error).message },
+    };
+  }
+}
+
+/** Resolve an asset path on disk (under <ProjectContent>/) to confirm the .uasset exists. */
+export async function uassetExists(
+  assetPath: string
+): Promise<RequirementResult> {
+  const data = await pyJson(`
+import unreal
+import os
+content_dir = unreal.Paths.project_content_dir()
+rel = ${JSON.stringify(assetPath)}.replace("/Game/", "").split(".")[0]
+disk = os.path.normpath(os.path.join(content_dir, rel + ".uasset"))
+_write_result({"disk": disk, "exists": os.path.isfile(disk)})
+`);
+  return {
+    passed: data.exists === true,
+    detail: data.exists
+      ? `.uasset on disk: ${data.disk}`
+      : `.uasset missing on disk: ${data.disk}`,
+    observed: data,
+  };
+}
+
+// ─── Internal: pyQuery wrapper ─────────────────────────────────────────
+
+async function pyJson(code: string): Promise<Record<string, unknown>> {
+  const result = await runPython({ code });
+  if (!result.success) {
+    throw new Error(
+      `Python failed: ${result.error}\n${result.traceback ?? ""}`
+    );
+  }
+  return (result.result ?? {}) as Record<string, unknown>;
+}

--- a/bridge/tests/e2e/runner/claude-runner.ts
+++ b/bridge/tests/e2e/runner/claude-runner.ts
@@ -1,0 +1,161 @@
+/**
+ * Spawn the Claude Code CLI headless with the bridge attached, feed it a
+ * prompt via stdin, capture the JSON response.
+ *
+ * Windows quirk: `claude` is normally `claude.cmd` (npm-installed) which Node's
+ * `spawn` can't resolve directly. Route through `cmd.exe /s /c "claude ..."`
+ * the same way `Source/Arbor/Private/ArborChatWidget.cpp:1086-1097` does.
+ *
+ * Permissions: this uses `--dangerously-skip-permissions` because the run is
+ * unattended (no human to approve tool calls). Risk is bounded by the scenario
+ * cleanup hooks (`clearActorsByPrefix` + `deleteAssetsUnder`) and the fact
+ * that Claude is talking to a *test* editor port via the bridge.
+ */
+
+import { spawn } from "node:child_process";
+import { writeMcpConfig } from "./mcp-config.js";
+
+export interface ClaudeRunResult {
+  exitCode: number;
+  /** Final assistant text, parsed from `--output-format json`. */
+  finalText: string | null;
+  /** The Claude session id, used to find the transcript file. */
+  sessionId: string | null;
+  /** Total cost reported by Claude (USD), if available. */
+  totalCostUsd: number | null;
+  /** Wall-clock duration of the Claude process in ms. */
+  durationMs: number;
+  /** Number of turns Claude took (assistant messages). */
+  numTurns: number | null;
+  /** Stdout, captured verbatim — useful for the report when JSON parse fails. */
+  rawStdout: string;
+  /** Stderr, captured verbatim — useful when the process exits non-zero. */
+  rawStderr: string;
+  /** Whether the prompt-stream produced a parseable final JSON object. */
+  parsed: boolean;
+}
+
+export interface RunClaudeOptions {
+  /** Prompt to pass to Claude (via stdin to avoid shell-quoting issues). */
+  prompt: string;
+  /** Working directory for Claude (defaults to the project root). */
+  cwd?: string;
+  /** Hard cap in ms; the process is killed if it exceeds this. */
+  timeoutMs?: number;
+  /** Optional model override (e.g. "claude-sonnet-4-6"). */
+  model?: string;
+}
+
+export async function runClaude(opts: RunClaudeOptions): Promise<ClaudeRunResult> {
+  const mcp = await writeMcpConfig();
+  const start = Date.now();
+
+  try {
+    const args = [
+      "--print",
+      "--mcp-config",
+      mcp.configPath,
+      "--dangerously-skip-permissions",
+      "--output-format",
+      "json",
+    ];
+    if (opts.model) args.push("--model", opts.model);
+
+    const isWindows = process.platform === "win32";
+
+    // On Windows, route through cmd.exe so PATHEXT (.cmd, .bat) resolves.
+    // We don't need shell expansion on the prompt itself — that's fed via stdin.
+    const cmd = isWindows ? "cmd.exe" : "claude";
+    const spawnArgs = isWindows
+      ? ["/s", "/c", `claude ${args.map(quoteForCmd).join(" ")}`]
+      : args;
+
+    const child = spawn(cmd, spawnArgs, {
+      cwd: opts.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on("data", (b: Buffer) => stdoutChunks.push(b));
+    child.stderr.on("data", (b: Buffer) => stderrChunks.push(b));
+
+    // Feed prompt via stdin
+    child.stdin.write(opts.prompt);
+    child.stdin.end();
+
+    let timedOut = false;
+    let timer: NodeJS.Timeout | null = null;
+    if (opts.timeoutMs) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, opts.timeoutMs);
+    }
+
+    const exitCode: number = await new Promise((resolve) => {
+      child.on("exit", (code) => resolve(code ?? 1));
+      child.on("error", () => resolve(1));
+    });
+    if (timer) clearTimeout(timer);
+
+    const rawStdout = Buffer.concat(stdoutChunks).toString("utf-8");
+    const rawStderr = Buffer.concat(stderrChunks).toString("utf-8");
+
+    const parsed = parseFinalJson(rawStdout);
+    return {
+      exitCode: timedOut ? 124 : exitCode,
+      finalText: parsed?.result ?? null,
+      sessionId: parsed?.session_id ?? null,
+      totalCostUsd: parsed?.total_cost_usd ?? null,
+      numTurns: parsed?.num_turns ?? null,
+      durationMs: Date.now() - start,
+      rawStdout,
+      rawStderr,
+      parsed: parsed !== null,
+    };
+  } finally {
+    await mcp.cleanup();
+  }
+}
+
+interface ClaudePrintJson {
+  result?: string;
+  session_id?: string;
+  total_cost_usd?: number;
+  num_turns?: number;
+}
+
+/**
+ * Claude's `--output-format json` writes a single JSON object to stdout when
+ * done. We tolerate a trailing newline and a possible streamed initialization
+ * line by trying to parse the last `{...}` block.
+ */
+function parseFinalJson(stdout: string): ClaudePrintJson | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  // Fast path: the whole stdout is the JSON object
+  try {
+    return JSON.parse(trimmed) as ClaudePrintJson;
+  } catch {
+    /* fall through */
+  }
+  // Fallback: find the last `{` that opens a top-level object
+  const lastOpen = trimmed.lastIndexOf("\n{");
+  if (lastOpen >= 0) {
+    try {
+      return JSON.parse(trimmed.slice(lastOpen + 1)) as ClaudePrintJson;
+    } catch {
+      /* give up */
+    }
+  }
+  return null;
+}
+
+/** Minimal cmd.exe quoting for arg values. We control the call site, so the
+ * paths are well-formed; we only need to wrap things with spaces. */
+function quoteForCmd(arg: string): string {
+  if (/\s/.test(arg)) return `"${arg.replace(/"/g, '\\"')}"`;
+  return arg;
+}

--- a/bridge/tests/e2e/runner/mcp-config.ts
+++ b/bridge/tests/e2e/runner/mcp-config.ts
@@ -1,0 +1,68 @@
+/**
+ * Generates a temp `.mcp.json` that registers the local bridge build under
+ * `ue5-bridge`, so the spawned Claude process talks to the *same* UE5 editor
+ * the test suite is using.
+ *
+ * The bridge is the one in `bridge/dist/index.js` relative to this file. The
+ * UE5_REMOTE_PORT env var is propagated from `global-setup.ts` so Claude's
+ * bridge instance points at the test-suite editor port (e.g. 30020), not the
+ * default 30010.
+ */
+
+import { writeFile, mkdtemp, unlink, rmdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Absolute path to the built bridge entry point (`bridge/dist/index.js`). */
+function bridgeEntryPath(): string {
+  // tests/e2e/runner/mcp-config.ts -> bridge/dist/index.js
+  return resolve(__dirname, "..", "..", "..", "dist", "index.js");
+}
+
+export interface McpConfigHandle {
+  configPath: string;
+  cleanup(): Promise<void>;
+}
+
+export async function writeMcpConfig(): Promise<McpConfigHandle> {
+  const dir = await mkdtemp(join(tmpdir(), "arbor-e2e-mcp-"));
+  const configPath = join(dir, "mcp.json");
+
+  const port = process.env.UE5_REMOTE_PORT ?? "30010";
+
+  const config = {
+    mcpServers: {
+      "ue5-bridge": {
+        command: "node",
+        args: [bridgeEntryPath()],
+        env: {
+          UE5_REMOTE_PORT: port,
+          // Inherit feature flags so e2e runs use whatever the host has enabled
+          ARBOR_TOOLS: process.env.ARBOR_TOOLS ?? "",
+        },
+      },
+    },
+  };
+
+  await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+
+  return {
+    configPath,
+    cleanup: async () => {
+      try {
+        await unlink(configPath);
+      } catch {
+        /* best-effort */
+      }
+      try {
+        await rmdir(dir);
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
+}

--- a/bridge/tests/e2e/runner/report-writer.ts
+++ b/bridge/tests/e2e/runner/report-writer.ts
@@ -1,0 +1,249 @@
+/**
+ * Writes the per-run JSON + self-contained HTML report.
+ *
+ * The HTML report is intentionally one file with inlined CSS and base64-encoded
+ * screenshots so it can be moved/emailed/zipped without breaking. No runtime
+ * deps beyond Node built-ins.
+ */
+
+import { promises as fs } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, join, basename } from "node:path";
+import type { Scenario, RequirementResult } from "../helpers/requirement.js";
+import type { ClaudeRunResult } from "./claude-runner.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Output root: `bridge/tests/e2e/.results/`. */
+function resultsRoot(): string {
+  return resolve(__dirname, "..", ".results");
+}
+
+export interface ScenarioReport {
+  scenario: { id: string; name: string };
+  /** Set when ARBOR_E2E_PROJECT is in the env at run time. */
+  projectTag: string | null;
+  startedIso: string;
+  finishedIso: string;
+  durationMs: number;
+  claude: {
+    exitCode: number;
+    sessionId: string | null;
+    finalText: string | null;
+    totalCostUsd: number | null;
+    numTurns: number | null;
+    durationMs: number;
+    parsed: boolean;
+    /** Truncated stdout/stderr — always available, even when parse failed. */
+    rawStdoutTail: string;
+    rawStderrTail: string;
+  };
+  requirements: Array<{
+    id: string;
+    name: string;
+    category: string;
+    passed: boolean;
+    detail: string;
+    observed?: unknown;
+  }>;
+  screenshots: string[];
+  summary: { total: number; passed: number; failed: number };
+}
+
+export interface WriteReportInput {
+  scenario: Scenario;
+  startedMs: number;
+  claudeResult: ClaudeRunResult;
+  requirementResults: Array<
+    RequirementResult & { id: string; name: string; category: string }
+  >;
+  screenshotPaths: string[];
+}
+
+export async function writeReport(
+  input: WriteReportInput
+): Promise<{ dir: string; jsonPath: string; htmlPath: string }> {
+  const finished = Date.now();
+  const stamp = new Date(input.startedMs)
+    .toISOString()
+    .replace(/[:.]/g, "-");
+  // ARBOR_E2E_PROJECT lets a sweep across multiple UE projects keep their
+  // reports separated. Sanitize to avoid weird filesystem chars.
+  const projectTag =
+    process.env.ARBOR_E2E_PROJECT?.replace(/[^\w.-]/g, "_") || null;
+  const dirName = projectTag
+    ? `${input.scenario.id}__${projectTag}__${stamp}`
+    : `${input.scenario.id}-${stamp}`;
+  const dir = join(resultsRoot(), dirName);
+  await fs.mkdir(dir, { recursive: true });
+
+  const passed = input.requirementResults.filter((r) => r.passed).length;
+  const report: ScenarioReport = {
+    scenario: { id: input.scenario.id, name: input.scenario.name },
+    projectTag,
+    startedIso: new Date(input.startedMs).toISOString(),
+    finishedIso: new Date(finished).toISOString(),
+    durationMs: finished - input.startedMs,
+    claude: {
+      exitCode: input.claudeResult.exitCode,
+      sessionId: input.claudeResult.sessionId,
+      finalText: input.claudeResult.finalText,
+      totalCostUsd: input.claudeResult.totalCostUsd,
+      numTurns: input.claudeResult.numTurns,
+      durationMs: input.claudeResult.durationMs,
+      parsed: input.claudeResult.parsed,
+      rawStdoutTail: input.claudeResult.rawStdout.slice(-4000),
+      rawStderrTail: input.claudeResult.rawStderr.slice(-4000),
+    },
+    requirements: input.requirementResults.map((r) => ({
+      id: r.id,
+      name: r.name,
+      category: r.category,
+      passed: r.passed,
+      detail: r.detail,
+      observed: r.observed,
+    })),
+    screenshots: input.screenshotPaths,
+    summary: {
+      total: input.requirementResults.length,
+      passed,
+      failed: input.requirementResults.length - passed,
+    },
+  };
+
+  const jsonPath = join(dir, "report.json");
+  await fs.writeFile(jsonPath, JSON.stringify(report, null, 2), "utf-8");
+
+  const htmlPath = join(dir, "report.html");
+  await fs.writeFile(htmlPath, await renderHtml(report), "utf-8");
+
+  return { dir, jsonPath, htmlPath };
+}
+
+async function renderHtml(report: ScenarioReport): Promise<string> {
+  const screenshotMarkup = await Promise.all(
+    report.screenshots.map(async (p) => {
+      try {
+        const data = await fs.readFile(p);
+        const mime = p.toLowerCase().endsWith(".jpg") ||
+          p.toLowerCase().endsWith(".jpeg")
+          ? "image/jpeg"
+          : "image/png";
+        const b64 = data.toString("base64");
+        return `<figure class="shot"><img src="data:${mime};base64,${b64}" alt="${escapeHtml(basename(p))}"/><figcaption>${escapeHtml(basename(p))}</figcaption></figure>`;
+      } catch {
+        return `<figure class="shot missing"><figcaption>missing: ${escapeHtml(p)}</figcaption></figure>`;
+      }
+    })
+  );
+
+  const reqRows = report.requirements
+    .map((r) => {
+      const cls = r.passed ? "pass" : "fail";
+      const observed =
+        r.observed !== undefined
+          ? `<details><summary>observed</summary><pre>${escapeHtml(JSON.stringify(r.observed, null, 2))}</pre></details>`
+          : "";
+      return `<tr class="${cls}">
+  <td class="status">${r.passed ? "PASS" : "FAIL"}</td>
+  <td><code>${escapeHtml(r.category)}</code></td>
+  <td>${escapeHtml(r.name)}</td>
+  <td>${escapeHtml(r.detail)}${observed}</td>
+</tr>`;
+    })
+    .join("\n");
+
+  const summaryClass = report.summary.failed === 0 ? "all-pass" : "has-fail";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>Arbor E2E — ${escapeHtml(report.scenario.name)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 1100px; margin: 1.5rem auto; padding: 0 1rem; }
+  h1 { margin-bottom: 0.25rem; }
+  .meta { color: #666; font-size: 13px; margin-bottom: 1rem; }
+  .summary { padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1.25rem; font-weight: 600; }
+  .summary.all-pass { background: #d4edda; color: #155724; }
+  .summary.has-fail { background: #f8d7da; color: #721c24; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #e0e0e0; vertical-align: top; }
+  th { font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: #555; }
+  tr.pass .status { color: #198754; font-weight: 600; }
+  tr.fail .status { color: #dc3545; font-weight: 600; }
+  tr.fail { background: rgba(220, 53, 69, 0.06); }
+  pre { background: #f5f5f5; padding: 8px 10px; border-radius: 4px; font-size: 12px; overflow-x: auto; max-height: 300px; }
+  details summary { cursor: pointer; color: #555; font-size: 12px; margin-top: 4px; }
+  .shots { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }
+  figure.shot { margin: 0; }
+  figure.shot img { width: 100%; border: 1px solid #ddd; border-radius: 4px; }
+  figure.shot figcaption { font-size: 12px; color: #666; margin-top: 4px; word-break: break-all; }
+  figure.missing { padding: 1rem; background: #f5f5f5; border-radius: 4px; text-align: center; color: #999; }
+  section { margin-bottom: 2rem; }
+  code { background: #f5f5f5; padding: 1px 6px; border-radius: 3px; font-size: 12.5px; }
+  .claude-meta { display: grid; grid-template-columns: max-content auto; gap: 4px 12px; font-size: 13px; }
+  .claude-meta dt { color: #555; font-weight: 600; }
+  .final-text { white-space: pre-wrap; background: #f9f9f9; padding: 10px; border-radius: 4px; border-left: 3px solid #aaa; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(report.scenario.name)}${report.projectTag ? ` <span style="color:#666;font-weight:400;">[${escapeHtml(report.projectTag)}]</span>` : ""}</h1>
+<div class="meta">
+  scenario id: <code>${escapeHtml(report.scenario.id)}</code>
+  ${report.projectTag ? `· project: <code>${escapeHtml(report.projectTag)}</code>` : ""}
+  · started ${escapeHtml(report.startedIso)}
+  · duration ${(report.durationMs / 1000).toFixed(1)}s
+</div>
+
+<div class="summary ${summaryClass}">
+  ${report.summary.passed} / ${report.summary.total} requirements passed
+  ${report.summary.failed > 0 ? `· <strong>${report.summary.failed} failed</strong>` : ""}
+  · Claude exit ${report.claude.exitCode}${report.claude.totalCostUsd !== null ? ` · cost $${report.claude.totalCostUsd.toFixed(4)}` : ""}
+</div>
+
+<section>
+  <h2>Requirements</h2>
+  <table>
+    <thead><tr><th>Status</th><th>Category</th><th>Requirement</th><th>Detail</th></tr></thead>
+    <tbody>
+${reqRows}
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2>Screenshots (${report.screenshots.length})</h2>
+  ${report.screenshots.length === 0
+    ? "<p><em>No screenshots collected.</em></p>"
+    : `<div class="shots">${screenshotMarkup.join("")}</div>`}
+</section>
+
+<section>
+  <h2>Claude run</h2>
+  <dl class="claude-meta">
+    <dt>exit code</dt><dd>${report.claude.exitCode}</dd>
+    <dt>parsed JSON</dt><dd>${report.claude.parsed ? "yes" : "no"}</dd>
+    <dt>session id</dt><dd>${escapeHtml(report.claude.sessionId ?? "(none)")}</dd>
+    <dt>turns</dt><dd>${report.claude.numTurns ?? "(unknown)"}</dd>
+    <dt>duration</dt><dd>${(report.claude.durationMs / 1000).toFixed(1)}s</dd>
+    <dt>cost</dt><dd>${report.claude.totalCostUsd !== null ? `$${report.claude.totalCostUsd.toFixed(4)}` : "(unknown)"}</dd>
+  </dl>
+  ${report.claude.finalText ? `<h3>Final assistant text</h3><div class="final-text">${escapeHtml(report.claude.finalText)}</div>` : ""}
+  <details><summary>raw stdout (tail)</summary><pre>${escapeHtml(report.claude.rawStdoutTail)}</pre></details>
+  <details><summary>raw stderr (tail)</summary><pre>${escapeHtml(report.claude.rawStderrTail)}</pre></details>
+</section>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/bridge/tests/e2e/scenarios/tiny-arena.ts
+++ b/bridge/tests/e2e/scenarios/tiny-arena.ts
@@ -1,0 +1,167 @@
+/**
+ * "Tiny Arena" — first E2E scenario.
+ *
+ * High-level prompt that exercises 7 of the 11 stable MCP categories:
+ *   actors, materials, lighting, blueprint, ai, capture, (implicit) assets
+ *
+ * The prompt deliberately pins down predictable labels and asset paths so the
+ * validators can find what Claude built. We're testing Claude's tool-routing
+ * judgment on the *how*, not its naming creativity.
+ */
+
+import type { Scenario } from "../helpers/requirement.js";
+import {
+  actorWithLabelExists,
+  countActorsWithLabel,
+  actorOfClassExists,
+  outdoorLightingPresent,
+  wallAndFloorMaterialsDiffer,
+  blueprintAtPath,
+  uassetExists,
+  characterBpHasAiControllerWired,
+  behaviorTreePathFromCharacter,
+  behaviorTreeContainsNodeClass,
+  screenshotIsNotBlank,
+  findLatestScreenshotSince,
+} from "../helpers/validators.js";
+
+const ENEMY_BP_PATH = "/Game/E2E/Tiny/BP_E2EEnemy_Tiny";
+const FLOOR_LABEL = "E2E_TinyArena_Floor";
+const WALL_LABEL = "E2E_TinyArena_Wall_";
+const ENEMY_LABEL = "E2E_TinyArena_Enemy";
+
+// Captured at module-load time so the screenshot search ignores anything older.
+const SCENARIO_LOAD_MS = Date.now();
+
+export const tinyArena: Scenario = {
+  id: "tiny-arena",
+  name: "Tiny Arena",
+  assetCleanupRoot: "/Game/E2E",
+  actorPrefix: "E2E_TinyArena_",
+
+  prompt: `You are running inside an automated end-to-end test for the Arbor MCP toolset.
+Build a small enclosed test arena in the currently open level. Use the ue5_* MCP
+tools — do NOT ask the user for input, do NOT pause, finish in one pass.
+
+Required setup:
+
+1. A floor roughly 20x20 metres centred at the world origin (z = 0).
+   - Actor label: "E2E_TinyArena_Floor"
+
+2. Four walls forming a closed perimeter around the floor, ~3 metres tall.
+   - Actor labels: "E2E_TinyArena_Wall_N", "E2E_TinyArena_Wall_E",
+     "E2E_TinyArena_Wall_S", "E2E_TinyArena_Wall_W"
+
+3. A material applied to the walls that is visually distinct from the floor's
+   material (any colour difference is fine — the goal is that wall material
+   path != floor material path).
+
+4. Outdoor scene lighting (directional sun + sky). Use the lighting tool.
+
+5. A NavMesh volume covering the floor.
+
+6. One enemy character Blueprint:
+   - Asset path: "${ENEMY_BP_PATH}"
+   - Has an AIController whose Behavior Tree just runs a single BTTask_Wait task
+     (any wait time is fine).
+   - Spawn ONE instance inside the arena, label "${ENEMY_LABEL}_01".
+
+7. After everything is built, take an orbit screenshot of the arena (target
+   the world origin, distance ~2000, angle ~45). Report the screenshot file
+   path in your final summary.
+
+When done, write a short summary listing what you built and the screenshot path.
+Do not file any GitHub issues. Do not run a playtest. Do not modify anything
+outside the "/Game/E2E/" content directory or actors with the "E2E_TinyArena_"
+prefix.`,
+
+  requirements: [
+    {
+      id: "floor-exists",
+      name: "Floor actor exists",
+      category: "actors",
+      check: () => actorWithLabelExists(FLOOR_LABEL),
+    },
+    {
+      id: "four-walls",
+      name: "≥4 wall actors placed",
+      category: "actors",
+      check: () => countActorsWithLabel(WALL_LABEL, 4),
+    },
+    {
+      id: "wall-floor-materials-differ",
+      name: "Wall material is distinct from floor material",
+      category: "materials",
+      check: () => wallAndFloorMaterialsDiffer(FLOOR_LABEL, WALL_LABEL),
+    },
+    {
+      id: "outdoor-lighting",
+      name: "Outdoor lighting (DirectionalLight + Sky) present",
+      category: "lighting",
+      check: () => outdoorLightingPresent(),
+    },
+    {
+      id: "navmesh-volume",
+      name: "NavMeshBoundsVolume present",
+      category: "actors",
+      check: () => actorOfClassExists("NavMeshBoundsVolume"),
+    },
+    {
+      id: "enemy-bp-on-disk",
+      name: `Enemy BP exists on disk at ${ENEMY_BP_PATH}`,
+      category: "blueprint",
+      check: () => uassetExists(ENEMY_BP_PATH),
+    },
+    {
+      id: "enemy-bp-queryable",
+      name: "Enemy BP loadable via blueprint.query",
+      category: "blueprint",
+      check: () => blueprintAtPath(ENEMY_BP_PATH),
+    },
+    {
+      id: "enemy-bp-ai-wired",
+      name: "Enemy BP has AIControllerClass set on CDO",
+      category: "blueprint",
+      check: () => characterBpHasAiControllerWired(ENEMY_BP_PATH),
+    },
+    {
+      id: "bt-has-wait",
+      name: "Behavior Tree contains a BTTask_Wait node",
+      category: "ai",
+      check: async () => {
+        // Fallback root narrowed to the scenario's BT folder. Arbor's canonical
+        // AIController doesn't expose `default_behavior_tree`, so the resolver
+        // also walks the AIController BP's event graph and (last resort) takes
+        // the only BT in this folder.
+        const btPath = await behaviorTreePathFromCharacter(
+          ENEMY_BP_PATH,
+          "/Game/E2E/Tiny"
+        );
+        if (!btPath) {
+          return {
+            passed: false,
+            detail:
+              "no BT could be resolved from Character BP -> AIController (CDO, event graph, or folder scan)",
+            observed: { resolved_bt_path: null },
+          };
+        }
+        return behaviorTreeContainsNodeClass(btPath, "Wait");
+      },
+    },
+    {
+      id: "enemy-instance-spawned",
+      name: "≥1 enemy instance spawned in level",
+      category: "actors",
+      check: () => countActorsWithLabel(ENEMY_LABEL, 1),
+    },
+    {
+      id: "orbit-screenshot",
+      name: "Orbit screenshot was captured and is not blank",
+      category: "capture",
+      check: async () => {
+        const path = await findLatestScreenshotSince(SCENARIO_LOAD_MS);
+        return screenshotIsNotBlank(path);
+      },
+    },
+  ],
+};

--- a/bridge/tests/e2e/tiny-arena.e2e.test.ts
+++ b/bridge/tests/e2e/tiny-arena.e2e.test.ts
@@ -1,0 +1,122 @@
+/**
+ * E2E: Claude builds the Tiny Arena scenario from a single high-level prompt.
+ *
+ * Skipped unless BOTH:
+ *   - the UE5 editor is reachable (same gate as the integration suite)
+ *   - RUN_CLAUDE_E2E=1 is set in the environment (this test spawns the Claude
+ *     CLI, which costs API credits, so we don't run it on every `npm test`).
+ *
+ * Run:
+ *   set RUN_CLAUDE_E2E=1 && npx vitest run tests/e2e   (Windows cmd)
+ *   $env:RUN_CLAUDE_E2E="1"; npx vitest run tests/e2e  (PowerShell)
+ *   RUN_CLAUDE_E2E=1 npx vitest run tests/e2e          (bash)
+ */
+
+import { describe, it, expect } from "vitest";
+import { isConnected } from "../../src/ue5-client.js";
+import { tinyArena } from "./scenarios/tiny-arena.js";
+import { runClaude } from "./runner/claude-runner.js";
+import { writeReport } from "./runner/report-writer.js";
+import { clearActorsByPrefix, deleteAssetsUnder } from "./helpers/cleanup.js";
+import { findAllScreenshotsSince } from "./helpers/validators.js";
+import type { RequirementResult } from "./helpers/requirement.js";
+
+const editorRunning = await isConnected();
+const e2eEnabled = process.env.RUN_CLAUDE_E2E === "1";
+
+describe.runIf(editorRunning && e2eEnabled)(
+  "E2E: Tiny Arena via Claude",
+  () => {
+    it(
+      "Claude builds a valid tiny arena from the high-level prompt",
+      async () => {
+        // Clean slate: remove any leftover actors/assets from a prior run
+        await clearActorsByPrefix(tinyArena.actorPrefix);
+        await deleteAssetsUnder(tinyArena.assetCleanupRoot);
+
+        const startedMs = Date.now();
+
+        // Hand Claude the prompt. 10-min cap covers slow editor + network.
+        const claudeResult = await runClaude({
+          prompt: tinyArena.prompt,
+          timeoutMs: 600_000,
+        });
+
+        // Run validators sequentially. Multiple `runPython` calls in parallel
+        // race on UE5's shared Python globals (`_RESULT_PATH` is module-level
+        // in run-python.ts's wrapper) — we've seen scripts write to each
+        // other's result files, causing spurious timeouts and cross-attached
+        // tracebacks. Sequential is slower but correct.
+        const requirementResults: Array<
+          RequirementResult & { id: string; name: string; category: string }
+        > = [];
+        for (const r of tinyArena.requirements) {
+          try {
+            const res = await r.check();
+            requirementResults.push({
+              id: r.id,
+              name: r.name,
+              category: r.category,
+              ...res,
+            });
+          } catch (e) {
+            requirementResults.push({
+              id: r.id,
+              name: r.name,
+              category: r.category,
+              passed: false,
+              detail: `validator threw: ${(e as Error).message}`,
+              observed: { error: (e as Error).message },
+            });
+          }
+        }
+
+        // Collect every screenshot Claude produced for the HTML report
+        const screenshotPaths = await findAllScreenshotsSince(startedMs);
+
+        const { dir, htmlPath } = await writeReport({
+          scenario: tinyArena,
+          startedMs,
+          claudeResult,
+          requirementResults,
+          screenshotPaths,
+        });
+
+        const failed = requirementResults.filter((r) => !r.passed);
+        const summary =
+          `${requirementResults.length - failed.length}/${requirementResults.length} requirements passed`;
+        // Always log where the report landed — that's how a human triages
+        // a failed run.
+        // eslint-disable-next-line no-console
+        console.log(
+          `\n[E2E] ${summary} (Claude exit ${claudeResult.exitCode})\n[E2E] Report: ${htmlPath}\n[E2E] Dir:    ${dir}\n`
+        );
+
+        expect(
+          failed,
+          `Failed requirements: ${failed.map((f) => `${f.id} (${f.detail})`).join("; ")}`
+        ).toHaveLength(0);
+        expect(
+          claudeResult.exitCode,
+          `Claude exited non-zero. See report at ${htmlPath}`
+        ).toBe(0);
+
+        // Cleanup is best-effort and runs after assertions, so a failed run
+        // leaves the level intact for inspection.
+      },
+      900_000 // 15-minute hook timeout — Claude + UE5 builds can be slow
+    );
+  }
+);
+
+describe.skipIf(editorRunning && e2eEnabled)(
+  "E2E: Tiny Arena (skipped)",
+  () => {
+    it("set RUN_CLAUDE_E2E=1 and start the UE5 editor to enable this test", () => {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[E2E] Skipped — editorRunning=${editorRunning}, RUN_CLAUDE_E2E=${process.env.RUN_CLAUDE_E2E ?? "unset"}`
+      );
+    });
+  }
+);

--- a/bridge/tests/global-setup.ts
+++ b/bridge/tests/global-setup.ts
@@ -58,6 +58,33 @@ function loadEnvFile(): void {
 const RC_INI_SECTION =
   "[/Script/RemoteControlCommon.RemoteControlSettings]";
 const RC_PORT_KEY = "RemoteControlHttpServerPort";
+const RC_AUTOSTART_KEY = "bAutoStartWebServer";
+const RC_PYTHON_KEY = "bEnableRemotePythonExecution";
+// UE 5.5+ split console-command execution into its own permission
+// (RemoteControlSettings.h). 5.4 only checks bEnableRemotePythonExecution;
+// 5.5+ also gates `py <script>` on this flag.
+const RC_CONSOLE_KEY = "bAllowConsoleCommandRemoteExecution";
+
+/**
+ * Set or replace `key=value` inside an INI file's named section. Adds the
+ * section if missing, replaces an existing key, or appends a new key under
+ * the existing section.
+ */
+function setIniKey(
+  content: string,
+  section: string,
+  key: string,
+  value: string
+): string {
+  const keyRegex = new RegExp(`^(${key}\\s*=\\s*)\\S+`, "m");
+  if (keyRegex.test(content)) {
+    return content.replace(keyRegex, `$1${value}`);
+  }
+  if (content.includes(section)) {
+    return content.replace(section, `${section}\n${key}=${value}`);
+  }
+  return content + `\n${section}\n${key}=${value}\n`;
+}
 
 function patchRemoteControlConfig(
   projectPath: string,
@@ -73,34 +100,23 @@ function patchRemoteControlConfig(
   configPath = join(configDir, "RemoteControl.ini");
   configBackupPath = join(configDir, "RemoteControl.ini.testbackup");
 
-  // Back up the existing config if it exists
+  // Back up the existing config if it exists. We patch BOTH the port and the
+  // auto-start flag — projects that ship with `bAutoStartWebServer=False`
+  // (e.g. the dev project's hardened DefaultRemoteControl.ini) would otherwise
+  // load the plugin but never open the port, making the poll time out.
   if (existsSync(configPath)) {
     copyFileSync(configPath, configBackupPath);
-    // Patch the port in the existing file
     let content = readFileSync(configPath, "utf-8");
-    const portRegex = new RegExp(
-      `^(${RC_PORT_KEY}\\s*=\\s*)\\d+`,
-      "m"
-    );
-    if (portRegex.test(content)) {
-      content = content.replace(portRegex, `$1${port}`);
-    } else if (content.includes(RC_INI_SECTION)) {
-      // Section exists but no port key — add it after the section header
-      content = content.replace(
-        RC_INI_SECTION,
-        `${RC_INI_SECTION}\n${RC_PORT_KEY}=${port}`
-      );
-    } else {
-      // No section at all — append
-      content += `\n${RC_INI_SECTION}\n${RC_PORT_KEY}=${port}\n`;
-    }
+    content = setIniKey(content, RC_INI_SECTION, RC_PORT_KEY, String(port));
+    content = setIniKey(content, RC_INI_SECTION, RC_AUTOSTART_KEY, "True");
+    content = setIniKey(content, RC_INI_SECTION, RC_PYTHON_KEY, "True");
+    content = setIniKey(content, RC_INI_SECTION, RC_CONSOLE_KEY, "True");
     writeFileSync(configPath, content, "utf-8");
   } else {
-    // No config file — create one with just the port setting
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
       configPath,
-      `${RC_INI_SECTION}\n${RC_PORT_KEY}=${port}\n`,
+      `${RC_INI_SECTION}\n${RC_PORT_KEY}=${port}\n${RC_AUTOSTART_KEY}=True\n${RC_PYTHON_KEY}=True\n${RC_CONSOLE_KEY}=True\n`,
       "utf-8"
     );
     configBackupPath = null; // Nothing to restore — just delete on cleanup


### PR DESCRIPTION
Spawns Claude with the bridge attached, hands it a high-level scenario prompt, validates the result against the live editor, and writes a self-contained HTML+JSON report. Ships with the Tiny Arena scenario covering 7 of 11 stable categories.

global-setup now patches RemoteControl.ini with bAutoStartWebServer, bEnableRemotePythonExecution, and bAllowConsoleCommandRemoteExecution so the harness runs unattended on vanilla projects (5.4 through 5.7).

A run-tests skill ships under .claude/skills/ with env-var-driven paths so contributors can invoke compile, integration, e2e, and multi-engine sweep suites from their own checkouts.