### PR TITLE
Add ue5_level tool + ue5_actors.set_property

### DIFF
--- a/Source/Arbor/Private/ArborActorTools.cpp
+++ b/Source/Arbor/Private/ArborActorTools.cpp
@@ -1,4 +1,5 @@
 #include "ArborActorTools.h"
+#include "ArborPropertyJson.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "Editor.h"
@@ -588,6 +589,46 @@ static TArray<AActor*> ParseIgnoreActors(const TArray<TSharedPtr<FJsonValue>>* I
 		}
 	}
 	return Result;
+}
+
+// ============================================================================
+// SetActorProperty (reflection-based UPROPERTY edit)
+// ============================================================================
+
+FString UArborActorTools::SetActorProperty(const FString& ActorName, const FString& PropertyName, const FString& ValueJson)
+{
+	using namespace Arbor::Json;
+
+	AActor* Actor = UArborActorTools::FindActorByAnyIdentifier(ActorName);
+	if (!Actor)
+	{
+		return JsonError(FString::Printf(TEXT("Actor '%s' not found in current level"), *ActorName));
+	}
+
+	TSharedPtr<FJsonValue> Parsed;
+	if (!ParseJsonValue(ValueJson, Parsed))
+	{
+		return JsonError(FString::Printf(TEXT("Could not parse JSON value: %s"), *ValueJson));
+	}
+
+	Actor->Modify();
+	FString Error;
+	if (!ApplyJsonToProperty(Actor, PropertyName, Parsed, Error))
+	{
+		return JsonError(Error);
+	}
+	Actor->PostEditChange();
+
+	if (UPackage* Package = Actor->GetOutermost())
+	{
+		Package->MarkPackageDirty();
+	}
+
+	const TSharedRef<FJsonObject> Extra = MakeShared<FJsonObject>();
+	Extra->SetStringField(TEXT("actor_path"), Actor->GetPathName());
+	Extra->SetStringField(TEXT("actor_label"), Actor->GetActorLabel());
+	Extra->SetStringField(TEXT("property_name"), PropertyName);
+	return MakeJsonResult(true, FString(), Extra);
 }
 
 FString UArborActorTools::TraceGroundZ(const FString& ParamsJson)

--- a/Source/Arbor/Private/ArborLevelTools.cpp
+++ b/Source/Arbor/Private/ArborLevelTools.cpp
@@ -1,0 +1,132 @@
+#include "ArborLevelTools.h"
+#include "ArborPropertyJson.h"
+
+#include "Editor.h"
+#include "FileHelpers.h"
+#include "EngineUtils.h"
+#include "Engine/Engine.h"
+#include "Engine/Level.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogArborLevel, Log, All);
+
+namespace
+{
+	using Arbor::Json::MakeJsonResult;
+	using Arbor::Json::JsonError;
+
+	UWorld* GetEditorWorld()
+	{
+		return GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	}
+
+	FString GetWorldPackagePath(UWorld* World)
+	{
+		if (!World) return FString();
+		if (UPackage* Package = World->GetOutermost())
+		{
+			return Package->GetName();
+		}
+		return FString();
+	}
+}
+
+// ============================================================================
+// LoadLevel
+// ============================================================================
+
+FString UArborLevelTools::LoadLevel(const FString& AssetPath, bool bForce)
+{
+	if (AssetPath.IsEmpty())
+	{
+		return JsonError(TEXT("AssetPath is empty"));
+	}
+
+	UWorld* CurrentWorld = GetEditorWorld();
+	if (CurrentWorld)
+	{
+		UPackage* CurrentPackage = CurrentWorld->GetOutermost();
+		const bool bDirty = CurrentPackage && CurrentPackage->IsDirty();
+		if (bDirty && !bForce)
+		{
+			return JsonError(FString::Printf(
+				TEXT("Current level '%s' has unsaved changes. ")
+				TEXT("Call save_current first, or pass force=true to discard."),
+				*GetWorldPackagePath(CurrentWorld)));
+		}
+	}
+
+	const bool bLoadAsTemplate = false;
+	const bool bShowProgress = true;
+	FEditorFileUtils::LoadMap(AssetPath, bLoadAsTemplate, bShowProgress);
+
+	UWorld* NewWorld = GetEditorWorld();
+	const FString NewPath = GetWorldPackagePath(NewWorld);
+	if (NewPath.IsEmpty() || !NewPath.Contains(FPaths::GetBaseFilename(AssetPath)))
+	{
+		return JsonError(FString::Printf(TEXT("LoadMap returned but world is '%s', expected '%s'"),
+			*NewPath, *AssetPath));
+	}
+
+	const TSharedRef<FJsonObject> Extra = MakeShared<FJsonObject>();
+	Extra->SetStringField(TEXT("asset_path"), NewPath);
+	Extra->SetStringField(TEXT("level_name"), NewWorld ? NewWorld->GetMapName() : FString());
+	return MakeJsonResult(true, FString(), Extra);
+}
+
+// ============================================================================
+// SaveCurrentLevel
+// ============================================================================
+
+FString UArborLevelTools::SaveCurrentLevel()
+{
+	UWorld* World = GetEditorWorld();
+	if (!World)
+	{
+		return JsonError(TEXT("No active editor world"));
+	}
+
+	const bool bSaved = FEditorFileUtils::SaveCurrentLevel();
+	if (!bSaved)
+	{
+		return JsonError(FString::Printf(TEXT("SaveCurrentLevel failed for '%s'"),
+			*GetWorldPackagePath(World)));
+	}
+
+	const TSharedRef<FJsonObject> Extra = MakeShared<FJsonObject>();
+	Extra->SetStringField(TEXT("asset_path"), GetWorldPackagePath(World));
+	Extra->SetStringField(TEXT("level_name"), World->GetMapName());
+	return MakeJsonResult(true, FString(), Extra);
+}
+
+// ============================================================================
+// GetCurrentLevel
+// ============================================================================
+
+FString UArborLevelTools::GetCurrentLevel()
+{
+	UWorld* World = GetEditorWorld();
+	if (!World)
+	{
+		return JsonError(TEXT("No active editor world"));
+	}
+
+	UPackage* Package = World->GetOutermost();
+	const bool bIsDirty = Package && Package->IsDirty();
+
+	int32 ActorCount = 0;
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		++ActorCount;
+	}
+
+	const TSharedRef<FJsonObject> Extra = MakeShared<FJsonObject>();
+	Extra->SetStringField(TEXT("asset_path"), GetWorldPackagePath(World));
+	Extra->SetStringField(TEXT("level_name"), World->GetMapName());
+	Extra->SetBoolField(TEXT("is_dirty"), bIsDirty);
+	Extra->SetNumberField(TEXT("actor_count"), ActorCount);
+	return MakeJsonResult(true, FString(), Extra);
+}

--- a/Source/Arbor/Private/ArborPropertyJson.h
+++ b/Source/Arbor/Private/ArborPropertyJson.h
@@ -1,0 +1,324 @@
+// Shared JSON ↔ FProperty helpers for Arbor UFUNCTION tools that need
+// reflection-based property edits (UArborLevelTools, the SetActorProperty
+// path on UArborActorTools, ...).
+//
+// Header-only namespace, private to the module. UBlueprintBuilder still
+// has its own inline copy of similar logic for historical reasons; that
+// can be folded in later if a refactor is wanted.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "GameplayTagsManager.h"
+#include "GameplayTagContainer.h"
+#include "Misc/Paths.h"
+#include "UObject/UnrealType.h"
+
+namespace Arbor::Json
+{
+	inline FString MakeJsonResult(bool bSuccess, const FString& Message = FString(), const TSharedPtr<FJsonObject>& Extra = nullptr)
+	{
+		const TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+		Root->SetBoolField(TEXT("success"), bSuccess);
+		if (!Message.IsEmpty())
+		{
+			Root->SetStringField(bSuccess ? TEXT("message") : TEXT("error"), Message);
+		}
+		if (Extra.IsValid())
+		{
+			for (const auto& Pair : Extra->Values)
+			{
+				Root->SetField(Pair.Key, Pair.Value);
+			}
+		}
+		FString Out;
+		const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Root, Writer);
+		return Out;
+	}
+
+	inline FString JsonError(const FString& Message)
+	{
+		return MakeJsonResult(false, Message);
+	}
+
+	inline UClass* LoadClassByPath(const FString& ClassPath)
+	{
+		if (ClassPath.IsEmpty()) return nullptr;
+
+		UClass* Cls = FindObject<UClass>(nullptr, *ClassPath);
+		if (Cls) return Cls;
+
+		Cls = LoadObject<UClass>(nullptr, *ClassPath);
+		if (Cls) return Cls;
+
+		// Try with _C suffix for blueprint classes
+		if (!ClassPath.EndsWith(TEXT("_C")))
+		{
+			const FString WithSuffix = ClassPath + TEXT("_C");
+			Cls = LoadObject<UClass>(nullptr, *WithSuffix);
+		}
+		return Cls;
+	}
+
+	inline bool ParseJsonValue(const FString& ValueJson, TSharedPtr<FJsonValue>& OutValue)
+	{
+		// JSON spec requires a top-level object/array; property values are
+		// usually scalars. Wrap in an object to parse, then extract.
+		const FString Wrapped = FString::Printf(TEXT("{\"v\": %s}"), *ValueJson);
+		TSharedPtr<FJsonObject> Obj;
+		const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Wrapped);
+		if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+		{
+			return false;
+		}
+		OutValue = Obj->TryGetField(TEXT("v"));
+		return OutValue.IsValid();
+	}
+
+	/**
+	 * Apply a JSON value to a property on a UObject. Supported types:
+	 *   scalars (bool/int32/float/double/FString/FName)
+	 *   FGameplayTag (string), FGameplayTagContainer (array of tag strings)
+	 *   FObjectProperty / FSoftObjectProperty (asset path string)
+	 *   FClassProperty / FSoftClassProperty (class path string)
+	 *
+	 * Not yet supported: nested struct properties (other than the two tag
+	 * structs above), TArray, TMap, TSet.
+	 */
+	inline bool ApplyJsonToProperty(UObject* Object, const FString& PropertyName,
+		const TSharedPtr<FJsonValue>& JsonValue, FString& OutError)
+	{
+		if (!Object)
+		{
+			OutError = TEXT("null object");
+			return false;
+		}
+		if (!JsonValue.IsValid())
+		{
+			OutError = TEXT("invalid JSON value");
+			return false;
+		}
+
+		FProperty* Prop = Object->GetClass()->FindPropertyByName(FName(*PropertyName));
+		if (!Prop)
+		{
+			OutError = FString::Printf(TEXT("Property '%s' not found on %s"),
+				*PropertyName, *Object->GetClass()->GetName());
+			return false;
+		}
+		void* Addr = Prop->ContainerPtrToValuePtr<void>(Object);
+
+		// Tag-related structs — must come before generic FStructProperty fallback.
+		if (FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+		{
+			if (StructProp->Struct == TBaseStructure<FGameplayTag>::Get())
+			{
+				const FString TagString = JsonValue->AsString();
+				FGameplayTag Tag;
+				if (!TagString.IsEmpty())
+				{
+					Tag = UGameplayTagsManager::Get().RequestGameplayTag(FName(*TagString), false);
+					if (!Tag.IsValid())
+					{
+						OutError = FString::Printf(TEXT("Gameplay tag '%s' is not registered"), *TagString);
+						return false;
+					}
+				}
+				*static_cast<FGameplayTag*>(Addr) = Tag;
+				return true;
+			}
+
+			if (StructProp->Struct == TBaseStructure<FGameplayTagContainer>::Get())
+			{
+				const TArray<TSharedPtr<FJsonValue>>* JsonArray = nullptr;
+				if (!JsonValue->TryGetArray(JsonArray) || !JsonArray)
+				{
+					OutError = FString::Printf(
+						TEXT("Property '%s' is FGameplayTagContainer; expected JSON array of tag strings"),
+						*PropertyName);
+					return false;
+				}
+				FGameplayTagContainer Container;
+				for (const TSharedPtr<FJsonValue>& Elem : *JsonArray)
+				{
+					if (!Elem.IsValid()) continue;
+					const FString TagString = Elem->AsString();
+					if (TagString.IsEmpty()) continue;
+					const FGameplayTag Tag = UGameplayTagsManager::Get()
+						.RequestGameplayTag(FName(*TagString), false);
+					if (!Tag.IsValid())
+					{
+						OutError = FString::Printf(TEXT("Gameplay tag '%s' is not registered"), *TagString);
+						return false;
+					}
+					Container.AddTag(Tag);
+				}
+				*static_cast<FGameplayTagContainer*>(Addr) = Container;
+				return true;
+			}
+
+			OutError = FString::Printf(TEXT("Struct property '%s' (%s) not supported"),
+				*PropertyName, *StructProp->Struct->GetName());
+			return false;
+		}
+
+		if (FClassProperty* ClassProp = CastField<FClassProperty>(Prop))
+		{
+			const FString ClassPath = JsonValue->AsString();
+			UClass* Loaded = LoadClassByPath(ClassPath);
+			if (!Loaded)
+			{
+				OutError = FString::Printf(TEXT("Could not load class '%s'"), *ClassPath);
+				return false;
+			}
+			ClassProp->SetObjectPropertyValue(Addr, Loaded);
+			return true;
+		}
+
+		if (FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop))
+		{
+			const FString AssetPath = JsonValue->AsString();
+			UObject* Loaded = AssetPath.IsEmpty() ? nullptr
+				: StaticLoadObject(ObjProp->PropertyClass, nullptr, *AssetPath);
+			if (!Loaded && !AssetPath.IsEmpty() && !AssetPath.Contains(TEXT(".")))
+			{
+				const FString FullPath = AssetPath + TEXT(".") + FPaths::GetBaseFilename(AssetPath);
+				Loaded = StaticLoadObject(ObjProp->PropertyClass, nullptr, *FullPath);
+			}
+			if (!Loaded && !AssetPath.IsEmpty())
+			{
+				OutError = FString::Printf(TEXT("Could not load object '%s'"), *AssetPath);
+				return false;
+			}
+			ObjProp->SetObjectPropertyValue(Addr, Loaded);
+			return true;
+		}
+
+		if (FSoftObjectProperty* SoftObjProp = CastField<FSoftObjectProperty>(Prop))
+		{
+			const FString AssetPath = JsonValue->AsString();
+			*static_cast<FSoftObjectPtr*>(Addr) = FSoftObjectPath(AssetPath);
+			return true;
+		}
+
+		if (FSoftClassProperty* SoftClassProp = CastField<FSoftClassProperty>(Prop))
+		{
+			const FString ClassPath = JsonValue->AsString();
+			*static_cast<FSoftObjectPtr*>(Addr) = FSoftObjectPath(ClassPath);
+			return true;
+		}
+
+		if (FFloatProperty* FloatProp = CastField<FFloatProperty>(Prop))
+		{
+			FloatProp->SetPropertyValue(Addr, static_cast<float>(JsonValue->AsNumber()));
+			return true;
+		}
+		if (FDoubleProperty* DoubleProp = CastField<FDoubleProperty>(Prop))
+		{
+			DoubleProp->SetPropertyValue(Addr, JsonValue->AsNumber());
+			return true;
+		}
+		if (FIntProperty* IntProp = CastField<FIntProperty>(Prop))
+		{
+			IntProp->SetPropertyValue(Addr, static_cast<int32>(JsonValue->AsNumber()));
+			return true;
+		}
+		if (FBoolProperty* BoolProp = CastField<FBoolProperty>(Prop))
+		{
+			BoolProp->SetPropertyValue(Addr, JsonValue->AsBool());
+			return true;
+		}
+		if (FStrProperty* StrProp = CastField<FStrProperty>(Prop))
+		{
+			StrProp->SetPropertyValue(Addr, JsonValue->AsString());
+			return true;
+		}
+		if (FNameProperty* NameProp = CastField<FNameProperty>(Prop))
+		{
+			NameProp->SetPropertyValue(Addr, FName(*JsonValue->AsString()));
+			return true;
+		}
+
+		OutError = FString::Printf(TEXT("Unsupported property type for '%s' on %s"),
+			*PropertyName, *Object->GetClass()->GetName());
+		return false;
+	}
+
+	/** Read property → JSON value (best-effort summary; same scope as ApplyToProperty). */
+	inline TSharedPtr<FJsonValue> PropertyToJson(UObject* Object, FProperty* Prop)
+	{
+		if (!Object || !Prop) return MakeShared<FJsonValueNull>();
+		void* Addr = Prop->ContainerPtrToValuePtr<void>(Object);
+
+		if (FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+		{
+			if (StructProp->Struct == TBaseStructure<FGameplayTag>::Get())
+			{
+				const FGameplayTag* Tag = static_cast<const FGameplayTag*>(Addr);
+				return MakeShared<FJsonValueString>(Tag->IsValid() ? Tag->ToString() : FString());
+			}
+			if (StructProp->Struct == TBaseStructure<FGameplayTagContainer>::Get())
+			{
+				const FGameplayTagContainer* Container = static_cast<const FGameplayTagContainer*>(Addr);
+				TArray<TSharedPtr<FJsonValue>> Tags;
+				for (const FGameplayTag& Tag : Container->GetGameplayTagArray())
+				{
+					Tags.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+				}
+				return MakeShared<FJsonValueArray>(Tags);
+			}
+			return MakeShared<FJsonValueString>(FString::Printf(TEXT("<struct:%s>"), *StructProp->Struct->GetName()));
+		}
+		if (FClassProperty* ClassProp = CastField<FClassProperty>(Prop))
+		{
+			UClass* Cls = Cast<UClass>(ClassProp->GetObjectPropertyValue(Addr));
+			return MakeShared<FJsonValueString>(Cls ? Cls->GetPathName() : FString());
+		}
+		if (FObjectProperty* ObjProp = CastField<FObjectProperty>(Prop))
+		{
+			UObject* Val = ObjProp->GetObjectPropertyValue(Addr);
+			return MakeShared<FJsonValueString>(Val ? Val->GetPathName() : FString());
+		}
+		if (FSoftObjectProperty* SoftObjProp = CastField<FSoftObjectProperty>(Prop))
+		{
+			const FSoftObjectPtr* Soft = static_cast<const FSoftObjectPtr*>(Addr);
+			return MakeShared<FJsonValueString>(Soft->ToSoftObjectPath().ToString());
+		}
+		if (FSoftClassProperty* SoftClassProp = CastField<FSoftClassProperty>(Prop))
+		{
+			const FSoftObjectPtr* Soft = static_cast<const FSoftObjectPtr*>(Addr);
+			return MakeShared<FJsonValueString>(Soft->ToSoftObjectPath().ToString());
+		}
+		if (FFloatProperty* FloatProp = CastField<FFloatProperty>(Prop))
+		{
+			return MakeShared<FJsonValueNumber>(FloatProp->GetPropertyValue(Addr));
+		}
+		if (FDoubleProperty* DoubleProp = CastField<FDoubleProperty>(Prop))
+		{
+			return MakeShared<FJsonValueNumber>(DoubleProp->GetPropertyValue(Addr));
+		}
+		if (FIntProperty* IntProp = CastField<FIntProperty>(Prop))
+		{
+			return MakeShared<FJsonValueNumber>(IntProp->GetPropertyValue(Addr));
+		}
+		if (FBoolProperty* BoolProp = CastField<FBoolProperty>(Prop))
+		{
+			return MakeShared<FJsonValueBoolean>(BoolProp->GetPropertyValue(Addr));
+		}
+		if (FStrProperty* StrProp = CastField<FStrProperty>(Prop))
+		{
+			return MakeShared<FJsonValueString>(StrProp->GetPropertyValue(Addr));
+		}
+		if (FNameProperty* NameProp = CastField<FNameProperty>(Prop))
+		{
+			return MakeShared<FJsonValueString>(NameProp->GetPropertyValue(Addr).ToString());
+		}
+		return MakeShared<FJsonValueString>(FString::Printf(TEXT("<unsupported:%s>"), *Prop->GetClass()->GetName()));
+	}
+}

--- a/Source/Arbor/Public/ArborActorTools.h
+++ b/Source/Arbor/Public/ArborActorTools.h
@@ -99,6 +99,27 @@ public:
 	static FString ModifyActor(const FString& ParamsJson);
 
 	/**
+	 * Set an arbitrary UPROPERTY on an actor by reflection. Complements
+	 * ModifyActor (which is limited to transform/visibility/label) for
+	 * cases like brush extents, gameplay-tag fields, soft-class refs,
+	 * component overrides on the actor itself, etc.
+	 *
+	 * Marks the level package dirty on success — caller should follow up
+	 * with `level.save_current` to persist.
+	 *
+	 * @param ActorName     Display label (preferred) or internal FName.
+	 * @param PropertyName  UPROPERTY name on the actor.
+	 * @param ValueJson     JSON-encoded value. Supported types:
+	 *                        scalars (bool/int32/float/double/FString/FName),
+	 *                        FGameplayTag (string), FGameplayTagContainer (array of strings),
+	 *                        FObjectProperty/FSoftObjectProperty (asset path string),
+	 *                        FClassProperty/FSoftClassProperty (class path string).
+	 * @return JSON: {success, actor_path, actor_label, property_name, error?}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Actors")
+	static FString SetActorProperty(const FString& ActorName, const FString& PropertyName, const FString& ValueJson);
+
+	/**
 	 * Trace straight down at a world XY coordinate to find the ground Z.
 	 *
 	 * @param ParamsJson  JSON: {x, y, start_z?, trace_distance?, ignore_actors?:[label,...]}

--- a/Source/Arbor/Public/ArborLevelTools.h
+++ b/Source/Arbor/Public/ArborLevelTools.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "ArborLevelTools.generated.h"
+
+/**
+ * Editor-only level (map) navigation utilities.
+ *
+ * Fills the gap that public Arbor's `ue5_actors` only operates on the
+ * currently-open level — no way to navigate between maps or check which
+ * one is active. Pair: `LoadLevel` → `SaveCurrentLevel` for the round
+ * trip; `GetCurrentLevel` for orientation.
+ *
+ * MCP family: `ue5_level` (writes) + `ue5_level_query` (reads).
+ *
+ * NOTE: Arbitrary FProperty edits on actors live in
+ * `UArborActorTools::SetActorProperty` (next to `ModifyActor`) — that's
+ * where users look for actor-modify ops.
+ */
+UCLASS()
+class ARBOR_API UArborLevelTools : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Load a different map in the editor.
+	 * @param AssetPath  e.g. "/Game/Maps/MyLevel"
+	 * @param bForce     When false, fails if the current level has unsaved changes.
+	 *                   When true, discards unsaved changes and proceeds.
+	 * @return JSON: {success, asset_path, level_name, error?}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Level")
+	static FString LoadLevel(const FString& AssetPath, bool bForce = false);
+
+	/**
+	 * Save the currently-active level + all its dirty packages.
+	 * @return JSON: {success, asset_path, level_name, error?}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Level")
+	static FString SaveCurrentLevel();
+
+	/**
+	 * Inspect the editor's currently-active level.
+	 * @return JSON: {success, asset_path, level_name, is_dirty, actor_count}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Level")
+	static FString GetCurrentLevel();
+};

--- a/bridge/src/registry/actors.ts
+++ b/bridge/src/registry/actors.ts
@@ -43,6 +43,12 @@ export const actorsTool: CategoryTool = {
       required: ["actor_name"],
       optional: ["position", "rotation", "scale", "visible", "label"],
     },
+    set_property: {
+      summary:
+        "Set arbitrary UPROPERTY on an actor by reflection (covers brush extents, gameplay-tag fields, soft refs, etc. that modify doesn't). Marks dirty; follow with ue5_level.save_current to persist.",
+      required: ["actor_name", "property_name"],
+      optional: ["value"],
+    },
     snap_to_ground: {
       summary: "Snap actor to ground with optional offset",
       required: ["actor_name"],
@@ -94,8 +100,23 @@ export const actorsTool: CategoryTool = {
     asset_path: z.string().optional().describe("Content browser path to asset (place action)"),
     // delete
     actor_names: z.array(z.string()).optional().describe("Actor names/paths to delete"),
-    // modify
-    actor_name: z.string().optional().describe("Actor name/path to modify or snap"),
+    // modify, set_property
+    actor_name: z.string().optional().describe("Actor name/path/label to target"),
+    // set_property
+    property_name: z.string().optional().describe("UPROPERTY name on the actor (set_property)"),
+    value: z
+      .unknown()
+      .optional()
+      .describe(
+        [
+          "JSON value for set_property. Encoding by FProperty type:",
+          "  bool → true/false ; int32/float/double → number ; FString/FName → \"text\"",
+          "  FGameplayTag → \"Quest.A.B\" (must be registered)",
+          "  FGameplayTagContainer → [\"Quest.A\", \"Quest.B\"]",
+          "  FObjectProperty / FSoftObjectProperty → \"/Game/Path/Asset.Asset\"",
+          "  FClassProperty / FSoftClassProperty → \"/Script/Module.ClassName\" or \"/Game/BP_Foo.BP_Foo_C\"",
+        ].join("\n")
+      ),
     position: z
       .object({ x: z.number(), y: z.number(), z: z.number() })
       .optional()
@@ -231,6 +252,16 @@ export const actorsTool: CategoryTool = {
           visible: p.visible,
           label: p.label,
         }),
+      });
+    },
+
+    async set_property(p) {
+      if (!p.actor_name) throw new Error("actor_name is required for set_property");
+      if (!p.property_name) throw new Error("property_name is required for set_property");
+      return callArborJson("ArborActorTools", "SetActorProperty", {
+        ActorName: p.actor_name as string,
+        PropertyName: p.property_name as string,
+        ValueJson: JSON.stringify(p.value),
       });
     },
 

--- a/bridge/src/registry/level.ts
+++ b/bridge/src/registry/level.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { callArborJson } from "../ue5-client.js";
+import type { CategoryTool } from "./types.js";
+
+export const levelTool: CategoryTool = {
+  description:
+    "Level (map) navigation: load a different map, save the current one, query which level is open. " +
+    "Pair with ue5_actors.set_property to do reflection-based actor edits after a load.",
+
+  actionParams: {
+    load: {
+      summary:
+        "Open a different map in the editor. Errors if the current level has unsaved changes unless force=true.",
+      required: ["asset_path"],
+      optional: ["force"],
+    },
+    save_current: {
+      summary: "Save the active level + its dirty packages.",
+    },
+    current: {
+      summary:
+        "Inspect the currently-open level: returns {asset_path, level_name, is_dirty, actor_count}.",
+    },
+  },
+
+  readOnlyActions: ["current"],
+
+  schema: {
+    asset_path: z
+      .string()
+      .optional()
+      .describe("Map content path for `load`, e.g. /Game/Maps/MyLevel"),
+    force: z
+      .boolean()
+      .optional()
+      .describe(
+        "`load`: discard unsaved changes in current level. Default false (errors if dirty)."
+      ),
+  },
+
+  actions: {
+    async load(p) {
+      if (!p.asset_path) throw new Error("asset_path is required for load");
+      return callArborJson("ArborLevelTools", "LoadLevel", {
+        AssetPath: p.asset_path as string,
+        bForce: p.force === true,
+      });
+    },
+
+    async save_current() {
+      return callArborJson("ArborLevelTools", "SaveCurrentLevel", {});
+    },
+
+    async current() {
+      return callArborJson("ArborLevelTools", "GetCurrentLevel", {});
+    },
+  },
+};

--- a/bridge/src/registry/stable.ts
+++ b/bridge/src/registry/stable.ts
@@ -11,6 +11,7 @@ import { meshTool } from "./mesh.js";
 import { assetsTool } from "./assets.js";
 import { captureTool } from "./capture.js";
 import { playtestTool } from "./playtest.js";
+import { levelTool } from "./level.js";
 
 export interface StableToolEntry {
   name: string;
@@ -29,4 +30,5 @@ export const STABLE_TOOLS: StableToolEntry[] = [
   { name: "ue5_assets", tool: assetsTool },
   { name: "ue5_capture", tool: captureTool },
   { name: "ue5_playtest", tool: playtestTool },
+  { name: "ue5_level", tool: levelTool },
 ];


### PR DESCRIPTION
## Summary

Two related gaps in the bridge surfaced when authoring across multiple maps:

1. **`ue5_actors` operates only on the currently-open level** — no way to navigate between maps from MCP. New `ue5_level` family covers it:
   - `load` — open a different map (errors on dirty unless `force=true`)
   - `save_current` — save active level + dirty packages
   - `current` — query active level (path, name, dirty, actor count)

2. **`ue5_actors.modify` is limited to transform/visibility/label**, so any other UPROPERTY edit forced callers to fall back to `ue5_run_python` (often unavailable in restricted environments). New `ue5_actors.set_property` does reflection-based edits on:
   - scalars (bool/int/float/double/FString/FName)
   - `FGameplayTag`, `FGameplayTagContainer`
   - `FObjectProperty` / `FSoftObjectProperty` (asset path string)
   - `FClassProperty` / `FSoftClassProperty` (class path string)

   Marks the level dirty; pair with `ue5_level.save_current` to persist.

## Implementation

- `UArborLevelTools` — new C++ class with `LoadLevel`, `SaveCurrentLevel`, `GetCurrentLevel` UFUNCTIONs
- `UArborActorTools::SetActorProperty` — added next to `ModifyActor` for discoverability
- `ArborPropertyJson.h` — new private header with shared JSON ↔ FProperty helpers (\`namespace Arbor::Json\`) so future tools needing the same surface can reuse it without copy-paste
- `bridge/src/registry/level.ts` — new \`CategoryTool\` (\`ue5_level\` + \`ue5_level_query\`)
- `bridge/src/registry/actors.ts` — wires the new \`set_property\` action
- `bridge/src/registry/stable.ts` — registers \`levelTool\`

\`UBlueprintBuilder\` still has its own inline copy of similar reflection logic for historical reasons; folding it into \`ArborPropertyJson\` is a separate refactor.

## Test plan

- [x] TS bridge compiles cleanly (\`npm run build\`)
- [x] C++ compiles on UE 5.4 + 5.5 via the ArborCompileTests rig (5.6/5.7 not yet sweep-tested due to a wrapper-script issue, will follow up)
- [ ] Smoke-test in editor: \`ue5_level(action="load", asset_path="/Game/Maps/SomeMap")\`, \`ue5_actors(action="set_property", actor_name=..., property_name=..., value=...)\`, \`ue5_level(action="save_current")\`