### PR TITLE
Add actors.spawn_class to bypass the unreal.Rotator() footgun

### DIFF
--- a/Source/Arbor/Private/ArborSpawnTools.cpp
+++ b/Source/Arbor/Private/ArborSpawnTools.cpp
@@ -286,6 +286,97 @@ FString UArborSpawnTools::SpawnNavMesh(const FString& ParamsJson)
 }
 
 // ============================================================================
+// SpawnActorByClass
+// ============================================================================
+
+FString UArborSpawnTools::SpawnActorByClass(const FString& ParamsJson)
+{
+	auto Params = ParseJson(ParamsJson);
+	if (!Params.IsValid())
+	{
+		return TEXT("{\"success\":false,\"error\":\"Invalid JSON\"}");
+	}
+
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World)
+	{
+		return TEXT("{\"success\":false,\"error\":\"No editor world\"}");
+	}
+
+	const FString ClassPath = GetOptStr(Params, TEXT("class_path"));
+	if (ClassPath.IsEmpty())
+	{
+		return TEXT("{\"success\":false,\"error\":\"class_path is required\"}");
+	}
+
+	// Resolve UClass: try direct, then with `_C` suffix for Blueprint generated classes.
+	UClass* Class = LoadObject<UClass>(nullptr, *ClassPath);
+	if (!Class && !ClassPath.EndsWith(TEXT("_C")))
+	{
+		Class = LoadObject<UClass>(nullptr, *(ClassPath + TEXT("_C")));
+	}
+	if (!Class)
+	{
+		// Last resort: load as Blueprint asset and pull GeneratedClass
+		if (UBlueprint* BP = Cast<UBlueprint>(UEditorAssetLibrary::LoadAsset(ClassPath)))
+		{
+			if (BP->GeneratedClass) Class = BP->GeneratedClass;
+		}
+	}
+	if (!Class)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Could not load class '%s'\"}"), *ClassPath);
+	}
+	if (!Class->IsChildOf(AActor::StaticClass()))
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Class '%s' is not an AActor subclass\"}"), *ClassPath);
+	}
+
+	const double X = GetOpt(Params, TEXT("x"), 0);
+	const double Y = GetOpt(Params, TEXT("y"), 0);
+	const double Z = GetOpt(Params, TEXT("z"), 0);
+	const double Pitch = GetOpt(Params, TEXT("pitch"), 0);
+	const double Yaw = GetOpt(Params, TEXT("yaw"), 0);
+	const double Roll = GetOpt(Params, TEXT("roll"), 0);
+	const double SX = GetOpt(Params, TEXT("scale_x"), 1);
+	const double SY = GetOpt(Params, TEXT("scale_y"), 1);
+	const double SZ = GetOpt(Params, TEXT("scale_z"), 1);
+	const FString Label = GetOptStr(Params, TEXT("label"));
+
+	const FVector Location(X, Y, Z);
+	const FRotator Rotation(Pitch, Yaw, Roll);
+
+	AActor* Actor = GetEditorActorSubsystem()->SpawnActorFromClass(
+		TSubclassOf<AActor>(Class), Location, Rotation);
+	if (!Actor)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Failed to spawn '%s'\"}"), *ClassPath);
+	}
+
+	if (SX != 1.0 || SY != 1.0 || SZ != 1.0)
+	{
+		Actor->SetActorScale3D(FVector(SX, SY, SZ));
+	}
+	if (!Label.IsEmpty())
+	{
+		Actor->SetActorLabel(Label);
+	}
+
+	TSharedPtr<FJsonObject> LocObj = MakeShared<FJsonObject>();
+	LocObj->SetNumberField(TEXT("x"), X);
+	LocObj->SetNumberField(TEXT("y"), Y);
+	LocObj->SetNumberField(TEXT("z"), Z);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("success"), true);
+	Root->SetStringField(TEXT("actor_path"), Actor->GetPathName());
+	Root->SetStringField(TEXT("actor_name"), Actor->GetActorLabel().IsEmpty() ? Actor->GetName() : Actor->GetActorLabel());
+	Root->SetStringField(TEXT("class_path"), Class->GetPathName());
+	Root->SetObjectField(TEXT("location"), LocObj);
+	return SerializeJson(Root);
+}
+
+// ============================================================================
 // PlaceActor
 // ============================================================================
 

--- a/Source/Arbor/Public/ArborSpawnTools.h
+++ b/Source/Arbor/Public/ArborSpawnTools.h
@@ -38,6 +38,24 @@ public:
 	static FString SpawnNavMesh(const FString& ParamsJson);
 
 	/**
+	 * Spawn an actor of the given UClass at a transform.
+	 *
+	 * Side-steps the unreal.Rotator() positional-args footgun in Python —
+	 * `unreal.Rotator(pitch, yaw, roll)` silently puts values in wrong fields
+	 * because its positional order doesn't match what most callers expect.
+	 * Callers passing pitch/yaw/roll as discrete keys here never need to
+	 * construct an FRotator on the Python side.
+	 *
+	 * @param ParamsJson  JSON: {class_path, x, y, z, pitch, yaw, roll, scale_x, scale_y, scale_z, label}
+	 *                    class_path: e.g. "/Script/Engine.TargetPoint" (C++ class) or
+	 *                                "/Game/BP_MyActor.BP_MyActor_C" / "/Game/BP_MyActor"
+	 *                                (Blueprint — `_C` is appended automatically if omitted).
+	 * @return JSON: {success, actor_path, actor_name, class_path, location:{x,y,z}}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Spawn")
+	static FString SpawnActorByClass(const FString& ParamsJson);
+
+	/**
 	 * Place an actor from an asset path.
 	 *
 	 * @param ParamsJson  JSON: {asset_path, x, y, z, pitch, yaw, roll, scale_x, scale_y, scale_z}

--- a/bridge/src/registry/actors.ts
+++ b/bridge/src/registry/actors.ts
@@ -29,6 +29,12 @@ export const actorsTool: CategoryTool = {
       summary: "Spawn a navigation mesh volume",
       optional: ["x", "y", "z", "extent_x", "extent_y", "extent_z"],
     },
+    spawn_class: {
+      summary:
+        "Spawn an actor of the given UClass at a transform. Use this for any actor type that isn't a primitive/light/navmesh — e.g. /Script/Engine.TargetPoint, /Script/Engine.TriggerVolume, or a Blueprint generated class /Game/BP_Foo.BP_Foo_C (the _C suffix is auto-appended if you omit it). Pitch/yaw/roll are passed as discrete keys, so callers never construct an unreal.Rotator() — avoids the positional-arg footgun where Python's Rotator silently puts values in wrong fields.",
+      required: ["class_path"],
+      optional: ["x", "y", "z", "pitch", "yaw", "roll", "scale_x", "scale_y", "scale_z", "label"],
+    },
     place: {
       summary: "Place an asset from content browser into the level",
       required: ["asset_path"],
@@ -92,6 +98,13 @@ export const actorsTool: CategoryTool = {
     label: z.string().optional().describe("Actor label for readability"),
     // place
     asset_path: z.string().optional().describe("Content browser path to asset (place action)"),
+    // spawn_class
+    class_path: z
+      .string()
+      .optional()
+      .describe(
+        "Class path for spawn_class. Examples: /Script/Engine.TargetPoint, /Script/Engine.TriggerVolume, /Game/BP_Foo.BP_Foo_C (or just /Game/BP_Foo — _C suffix auto-appended)."
+      ),
     // delete
     actor_names: z.array(z.string()).optional().describe("Actor names/paths to delete"),
     // modify
@@ -189,6 +202,19 @@ export const actorsTool: CategoryTool = {
         ParamsJson: JSON.stringify({
           x: p.x, y: p.y, z: p.z,
           extent_x: p.extent_x, extent_y: p.extent_y, extent_z: p.extent_z,
+        }),
+      });
+    },
+
+    async spawn_class(p) {
+      if (!p.class_path) throw new Error("class_path is required for spawn_class");
+      return callArborJson("ArborSpawnTools", "SpawnActorByClass", {
+        ParamsJson: JSON.stringify({
+          class_path: p.class_path,
+          x: p.x, y: p.y, z: p.z,
+          pitch: p.pitch, yaw: p.yaw, roll: p.roll,
+          scale_x: p.scale_x, scale_y: p.scale_y, scale_z: p.scale_z,
+          label: p.label,
         }),
       });
     },


### PR DESCRIPTION
## Summary

\`unreal.Rotator()\`'s positional args silently put values in the wrong fields — Python's positional order doesn't match what most callers reach for, so \`unreal.Rotator(pitch, yaw, roll)\` produces wrong rotation. Existing wrappers (\`spawn_primitive\`, \`place\`, \`modify\`) already take pitch/yaw/roll as discrete keys and avoid this. But spawning an arbitrary actor class still required custom Python with a hand-rolled \`Rotator\`, where the bug bites.

New \`ue5_actors.spawn_class\` action takes \`class_path\` + explicit pitch/yaw/roll keys, builds the \`FRotator\` C++-side (which has a stable Pitch/Yaw/Roll constructor order), and spawns via \`SpawnActorFromClass\`:

\`\`\`
ue5_actors(action="spawn_class",
           class_path="/Script/Engine.TargetPoint",
           x=0, y=0, z=200, yaw=45)
\`\`\`

## Class path resolution

- C++ classes: \`/Script/Module.ClassName\`
- Blueprint generated classes: \`/Game/Path/BP_Foo.BP_Foo_C\` — or just \`/Game/Path/BP_Foo\` (the \`_C\` suffix is auto-appended)

## Implementation

- \`UArborSpawnTools::SpawnActorByClass\` — new UFUNCTION, same \`ParamsJson\` convention as the other \`Spawn*\` UFUNCTIONs in that class
- \`bridge/src/registry/actors.ts\` — wires the new \`spawn_class\` action

## Test plan

- [x] TS bridge compiles cleanly
- [ ] Smoke-test in editor: \`ue5_actors(action="spawn_class", class_path="/Script/Engine.TargetPoint", x=0, y=0, z=100)\`
- [ ] Spawn a Blueprint generated class with both \`/Game/BP_Foo.BP_Foo_C\` and \`/Game/BP_Foo\` paths