### PR TITLE
Add spawn_text + set_mesh_material; fix capture_from_position

### DIFF
--- a/Source/Arbor/Private/ArborActorTools.cpp
+++ b/Source/Arbor/Private/ArborActorTools.cpp
@@ -12,6 +12,9 @@
 #include "Serialization/JsonSerializer.h"
 #include "CollisionQueryParams.h"
 #include "ILiveCodingModule.h"
+#include "Components/StaticMeshComponent.h"
+#include "Components/MeshComponent.h"
+#include "Materials/MaterialInterface.h"
 
 // ============================================================================
 // Private helpers
@@ -881,4 +884,77 @@ FString UArborActorTools::LiveCompile()
 	}
 	LC->Compile();
 	return TEXT("{\"success\":true,\"message\":\"Live Coding compile triggered\"}");
+}
+
+// ============================================================================
+// SetMeshMaterial — override a material slot on an actor's mesh component
+// ============================================================================
+
+FString UArborActorTools::SetMeshMaterial(const FString& ActorName, int32 Slot, const FString& MaterialPath)
+{
+	if (Slot < 0)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Slot must be >= 0 (got %d)\"}"), Slot);
+	}
+
+	AActor* Actor = UArborActorTools::FindActorByAnyIdentifier(ActorName);
+	if (!Actor)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Actor '%s' not found\"}"), *ActorName);
+	}
+
+	UMaterialInterface* Material = Cast<UMaterialInterface>(StaticLoadObject(
+		UMaterialInterface::StaticClass(), nullptr, *MaterialPath));
+	if (!Material && !MaterialPath.IsEmpty() && !MaterialPath.Contains(TEXT(".")))
+	{
+		// Retry with full object path (e.g. /Game/Materials/M_Foo → /Game/Materials/M_Foo.M_Foo)
+		const FString Leaf = FPaths::GetBaseFilename(MaterialPath);
+		Material = Cast<UMaterialInterface>(StaticLoadObject(
+			UMaterialInterface::StaticClass(), nullptr, *(MaterialPath + TEXT(".") + Leaf)));
+	}
+	if (!Material)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Could not load material '%s'\"}"), *MaterialPath);
+	}
+
+	// Prefer StaticMeshComponent (the common case for placed mesh actors);
+	// fall back to any UMeshComponent (skeletal, instanced, etc.).
+	UMeshComponent* MeshComp = Actor->FindComponentByClass<UStaticMeshComponent>();
+	if (!MeshComp)
+	{
+		MeshComp = Actor->FindComponentByClass<UMeshComponent>();
+	}
+	if (!MeshComp)
+	{
+		return FString::Printf(TEXT("{\"success\":false,\"error\":\"Actor '%s' has no MeshComponent\"}"), *ActorName);
+	}
+
+	if (Slot >= MeshComp->GetNumMaterials())
+	{
+		return FString::Printf(
+			TEXT("{\"success\":false,\"error\":\"Slot %d out of range (component has %d slots)\"}"),
+			Slot, MeshComp->GetNumMaterials());
+	}
+
+	Actor->Modify();
+	MeshComp->Modify();
+	MeshComp->SetMaterial(Slot, Material);
+	Actor->PostEditChange();
+
+	if (UPackage* Package = Actor->GetOutermost())
+	{
+		Package->MarkPackageDirty();
+	}
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("success"), true);
+	Root->SetStringField(TEXT("actor_path"), Actor->GetPathName());
+	Root->SetStringField(TEXT("component"), MeshComp->GetName());
+	Root->SetNumberField(TEXT("slot"), Slot);
+	Root->SetStringField(TEXT("material_path"), Material->GetPathName());
+
+	FString Output;
+	auto Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Output);
+	FJsonSerializer::Serialize(Root.ToSharedRef(), Writer);
+	return Output;
 }

--- a/Source/Arbor/Private/ArborSpawnTools.cpp
+++ b/Source/Arbor/Private/ArborSpawnTools.cpp
@@ -2,6 +2,9 @@
 #include "Engine/World.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/StaticMeshActor.h"
+#include "Engine/TextRenderActor.h"
+#include "Components/TextRenderComponent.h"
+#include "Materials/MaterialInterface.h"
 #include "EngineUtils.h"
 #include "Editor.h"
 #include "Subsystems/EditorActorSubsystem.h"
@@ -571,5 +574,100 @@ FString UArborSpawnTools::ScatterMeshes(const FString& ParamsJson)
 	Root->SetBoolField(TEXT("success"), true);
 	Root->SetNumberField(TEXT("placed"), Placed);
 	Root->SetArrayField(TEXT("actors"), ActorsArray);
+	return SerializeJson(Root);
+}
+
+// ============================================================================
+// SpawnText
+// ============================================================================
+
+FString UArborSpawnTools::SpawnText(const FString& ParamsJson)
+{
+	auto Params = ParseJson(ParamsJson);
+	if (!Params.IsValid())
+	{
+		return TEXT("{\"success\":false,\"error\":\"Invalid JSON\"}");
+	}
+
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	if (!World)
+	{
+		return TEXT("{\"success\":false,\"error\":\"No editor world\"}");
+	}
+
+	const FString TextStr = GetOptStr(Params, TEXT("text"), TEXT("Text"));
+	const double X = GetOpt(Params, TEXT("x"), 0);
+	const double Y = GetOpt(Params, TEXT("y"), 0);
+	const double Z = GetOpt(Params, TEXT("z"), 0);
+	const double Pitch = GetOpt(Params, TEXT("pitch"), 0);
+	const double Yaw = GetOpt(Params, TEXT("yaw"), 0);
+	const double Roll = GetOpt(Params, TEXT("roll"), 0);
+	const double WorldSize = GetOpt(Params, TEXT("world_size"), 32.0);
+	const FString Label = GetOptStr(Params, TEXT("label"));
+
+	bool bLit = false;
+	Params->TryGetBoolField(TEXT("lit"), bLit);
+
+	double R = 1.0, G = 1.0, B = 1.0;
+	const TSharedPtr<FJsonObject>* ColorObj;
+	if (Params->TryGetObjectField(TEXT("color"), ColorObj))
+	{
+		R = GetOpt(*ColorObj, TEXT("r"), 1.0);
+		G = GetOpt(*ColorObj, TEXT("g"), 1.0);
+		B = GetOpt(*ColorObj, TEXT("b"), 1.0);
+	}
+
+	const FVector Location(X, Y, Z);
+	const FRotator Rotation(Pitch, Yaw, Roll);
+
+	AActor* Actor = GetEditorActorSubsystem()->SpawnActorFromClass(
+		ATextRenderActor::StaticClass(), Location, Rotation);
+	if (!Actor)
+	{
+		return TEXT("{\"success\":false,\"error\":\"Failed to spawn TextRenderActor\"}");
+	}
+
+	UTextRenderComponent* TRC = Actor->FindComponentByClass<UTextRenderComponent>();
+	if (TRC)
+	{
+		TRC->SetText(FText::FromString(TextStr));
+		TRC->SetTextRenderColor(FColor(
+			static_cast<uint8>(FMath::Clamp(R, 0.0, 1.0) * 255.0),
+			static_cast<uint8>(FMath::Clamp(G, 0.0, 1.0) * 255.0),
+			static_cast<uint8>(FMath::Clamp(B, 0.0, 1.0) * 255.0),
+			255));
+		TRC->SetWorldSize(WorldSize);
+
+		// Default to UnlitText so debug labels read consistently regardless
+		// of scene lighting. The TextRenderComponent default material is LIT,
+		// which gets tinted by the environment — rarely what callers want.
+		if (!bLit)
+		{
+			if (UMaterialInterface* Unlit = Cast<UMaterialInterface>(StaticLoadObject(
+				UMaterialInterface::StaticClass(), nullptr,
+				TEXT("/Engine/EngineMaterials/UnlitText.UnlitText"))))
+			{
+				TRC->SetTextMaterial(Unlit);
+			}
+		}
+	}
+
+	if (!Label.IsEmpty())
+	{
+		Actor->SetActorLabel(Label);
+	}
+
+	TSharedPtr<FJsonObject> LocObj = MakeShared<FJsonObject>();
+	LocObj->SetNumberField(TEXT("x"), X);
+	LocObj->SetNumberField(TEXT("y"), Y);
+	LocObj->SetNumberField(TEXT("z"), Z);
+
+	TSharedPtr<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetBoolField(TEXT("success"), true);
+	Root->SetStringField(TEXT("actor_path"), Actor->GetPathName());
+	Root->SetStringField(TEXT("actor_name"), Actor->GetActorLabel().IsEmpty() ? Actor->GetName() : Actor->GetActorLabel());
+	Root->SetStringField(TEXT("text"), TextStr);
+	Root->SetBoolField(TEXT("lit"), bLit);
+	Root->SetObjectField(TEXT("location"), LocObj);
 	return SerializeJson(Root);
 }

--- a/Source/Arbor/Public/ArborActorTools.h
+++ b/Source/Arbor/Public/ArborActorTools.h
@@ -120,6 +120,27 @@ public:
 	static FString SetActorProperty(const FString& ActorName, const FString& PropertyName, const FString& ValueJson);
 
 	/**
+	 * Override a material slot on an actor's mesh component.
+	 *
+	 * Goes through UMeshComponent::SetMaterial (the canonical UE path), which
+	 * routes the assignment into the component's OverrideMaterials array.
+	 * Reliable for already-placed actors — avoids the
+	 * `set_editor_property("override_materials", [mat])` workaround that
+	 * Python callers sometimes need when set_material silently no-ops on
+	 * uncommitted assignments.
+	 *
+	 * Targets the actor's primary mesh component (UStaticMeshComponent first,
+	 * falling back to any UMeshComponent).
+	 *
+	 * @param ActorName     Display label (preferred) or internal FName.
+	 * @param Slot          Material element index (0-based).
+	 * @param MaterialPath  Asset path of UMaterialInterface (material or instance).
+	 * @return JSON: {success, actor_path, component, slot, material_path, error?}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Actors")
+	static FString SetMeshMaterial(const FString& ActorName, int32 Slot, const FString& MaterialPath);
+
+	/**
 	 * Trace straight down at a world XY coordinate to find the ground Z.
 	 *
 	 * @param ParamsJson  JSON: {x, y, start_z?, trace_distance?, ignore_actors?:[label,...]}

--- a/Source/Arbor/Public/ArborSpawnTools.h
+++ b/Source/Arbor/Public/ArborSpawnTools.h
@@ -65,6 +65,20 @@ public:
 	static FString PlaceActor(const FString& ParamsJson);
 
 	/**
+	 * Spawn a TextRenderActor with sensible debug-text defaults.
+	 *
+	 * Defaults the material to /Engine/EngineMaterials/UnlitText so the text
+	 * reads consistently bright regardless of scene lighting — the LIT default
+	 * gets tinted by the environment, which is rarely what callers want for
+	 * debug labels. Pass `lit: true` to skip the override.
+	 *
+	 * @param ParamsJson  JSON: {text, x, y, z, pitch, yaw, roll, world_size, color:{r,g,b}, lit, label}
+	 * @return JSON: {success, actor_path, actor_name, text, location:{x,y,z}}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|Spawn")
+	static FString SpawnText(const FString& ParamsJson);
+
+	/**
 	 * Scatter static mesh actors randomly within a bounding box.
 	 * All spawning, random transform, and ground snapping in one C++ call.
 	 *

--- a/bridge/src/registry/actors.ts
+++ b/bridge/src/registry/actors.ts
@@ -35,10 +35,20 @@ export const actorsTool: CategoryTool = {
       required: ["class_path"],
       optional: ["x", "y", "z", "pitch", "yaw", "roll", "scale_x", "scale_y", "scale_z", "label"],
     },
+    spawn_text: {
+      summary:
+        "Spawn a TextRenderActor (3D text). Defaults the material to /Engine/EngineMaterials/UnlitText so debug labels read consistently bright regardless of scene lighting — pass lit=true to keep the LIT default that gets tinted by environment.",
+      optional: ["text", "x", "y", "z", "pitch", "yaw", "roll", "world_size", "color", "lit", "label"],
+    },
     place: {
       summary: "Place an asset from content browser into the level",
       required: ["asset_path"],
       optional: ["x", "y", "z", "pitch", "yaw", "roll", "scale_x", "scale_y", "scale_z"],
+    },
+    set_mesh_material: {
+      summary:
+        "Override a material slot on an actor's mesh component. Goes through MeshComponent::SetMaterial (the canonical path that handles the OverrideMaterials array), so it works on already-placed actors without needing the set_editor_property('override_materials',[mat]) workaround.",
+      required: ["actor_name", "slot", "material_path"],
     },
     delete: {
       summary: "Delete actors by name",
@@ -111,6 +121,18 @@ export const actorsTool: CategoryTool = {
       .describe(
         "Class path for spawn_class. Examples: /Script/Engine.TargetPoint, /Script/Engine.TriggerVolume, /Game/BP_Foo.BP_Foo_C (or just /Game/BP_Foo — _C suffix auto-appended)."
       ),
+    // spawn_text
+    text: z.string().optional().describe("Text content for spawn_text. Default 'Text'"),
+    world_size: z.number().optional().describe("Text world size for spawn_text. Default 32"),
+    lit: z
+      .boolean()
+      .optional()
+      .describe(
+        "spawn_text: keep the LIT TextRenderComponent default (gets tinted by environment). Default false → uses /Engine/EngineMaterials/UnlitText for consistent bright color."
+      ),
+    // set_mesh_material
+    slot: z.number().optional().describe("Material element index (set_mesh_material). 0-based."),
+    material_path: z.string().optional().describe("UMaterialInterface asset path (set_mesh_material)."),
     // delete
     actor_names: z.array(z.string()).optional().describe("Actor names/paths to delete"),
     // modify, set_property
@@ -237,6 +259,31 @@ export const actorsTool: CategoryTool = {
           scale_x: p.scale_x, scale_y: p.scale_y, scale_z: p.scale_z,
           label: p.label,
         }),
+      });
+    },
+
+    async spawn_text(p) {
+      return callArborJson("ArborSpawnTools", "SpawnText", {
+        ParamsJson: JSON.stringify({
+          text: p.text,
+          x: p.x, y: p.y, z: p.z,
+          pitch: p.pitch, yaw: p.yaw, roll: p.roll,
+          world_size: p.world_size,
+          color: p.color,
+          lit: p.lit,
+          label: p.label,
+        }),
+      });
+    },
+
+    async set_mesh_material(p) {
+      if (!p.actor_name) throw new Error("actor_name is required for set_mesh_material");
+      if (p.slot === undefined) throw new Error("slot is required for set_mesh_material");
+      if (!p.material_path) throw new Error("material_path is required for set_mesh_material");
+      return callArborJson("ArborActorTools", "SetMeshMaterial", {
+        ActorName: p.actor_name as string,
+        Slot: p.slot as number,
+        MaterialPath: p.material_path as string,
       });
     },
 

--- a/bridge/src/registry/capture.ts
+++ b/bridge/src/registry/capture.ts
@@ -169,12 +169,62 @@ else:
     },
 
     async capture_from_position(p) {
-      return callArborJson("ArborCaptureTools", "CaptureFromPosition", {
-        ParamsJson: JSON.stringify({
-          x: p.x ?? 0, y: p.y ?? 0, z: p.z ?? 0,
-          pitch: p.pitch ?? 0, yaw: p.yaw ?? 0, roll: p.roll ?? 0,
-        }),
-      });
+      // Route through the same Python path as `screenshot view="custom"`:
+      //   - The C++ ArborCaptureTools::CaptureFromPosition expects
+      //     {location:[x,y,z], rotation:[p,y,r]} arrays, not the
+      //     x/y/z/pitch/yaw/roll keys this action's schema documents — so
+      //     the C++ silently captured from the origin and returned a path
+      //     before the file finished writing.
+      //   - The Python helper take_screenshot_from() takes (loc, rot)
+      //     tuples, blocks until the file is on disk, and returns the path.
+      // Same wait-for-file + base64-image-return treatment as `screenshot`.
+      const pythonCall = `arbor.capture.take_screenshot_from((${p.x ?? 0}, ${p.y ?? 0}, ${p.z ?? 0}), (${p.pitch ?? 0}, ${p.yaw ?? 0}, ${p.roll ?? 0}))`;
+      const code = `
+import importlib
+import arbor.capture
+importlib.reload(arbor.capture)
+
+path = ${pythonCall}
+if path:
+    _write_result({"success": True, "screenshot_path": path})
+else:
+    _write_result({"success": False, "error": "Screenshot capture failed"})
+`;
+
+      const pyResult = await runPythonCode(code);
+      if (!pyResult.success || !pyResult.result) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: "Screenshot Python failed" }) }],
+          isError: true,
+        };
+      }
+
+      const data = pyResult.result as { success: boolean; screenshot_path?: string; error?: string };
+      if (!data.success || !data.screenshot_path) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: data.error ?? "No file produced" }) }],
+          isError: true,
+        };
+      }
+
+      const imageBuffer = await waitForScreenshotFile(data.screenshot_path);
+      if (!imageBuffer) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `File not written: ${data.screenshot_path}` }) }],
+          isError: true,
+        };
+      }
+
+      const base64 = imageBuffer.toString("base64");
+      const mimeType = data.screenshot_path.endsWith(".jpg") || data.screenshot_path.endsWith(".jpeg")
+        ? "image/jpeg" : "image/png";
+
+      return {
+        content: [
+          { type: "image", data: base64, mimeType },
+          { type: "text", text: JSON.stringify({ success: true, screenshot_path: data.screenshot_path }, null, 2) },
+        ],
+      };
     },
 
     async annotate(p) {


### PR DESCRIPTION
## Summary

Three rough edges surfaced during a session, all in or adjacent to \`ue5_actors\`:

### 1. \`ue5_actors.spawn_text\`

Spawns a \`TextRenderActor\`, defaults the material to \`/Engine/EngineMaterials/UnlitText\` so debug labels read consistently bright. The \`TextRenderComponent\`'s LIT default gets tinted by the environment, which is rarely what callers want for debug text. Pass \`lit: true\` to keep the LIT default.

### 2. \`ue5_actors.set_mesh_material\`

Wraps \`UMeshComponent::SetMaterial(slot, material)\`, the canonical UE path that updates the component's \`OverrideMaterials\` array. Reliable for already-placed actors, so callers don't need the \`set_editor_property("override_materials", [mat])\` workaround that sometimes shows up when \`set_material\` silently no-ops on uncommitted assignments.

### 3. \`ue5_capture.capture_from_position\` fix

Bridge handler was sending \`{x, y, z, pitch, yaw, roll}\` JSON, but the C++ side expected \`{location: [...], rotation: [...]}\` arrays. The C++ silently fell back to \`ZeroVector\`/\`ZeroRotator\` and returned a path *before* the file finished writing — callers got a non-existent screenshot path back.

Reroute through the same \`arbor.capture.take_screenshot_from()\` Python path that \`screenshot view="custom"\` uses — same file-wait, same base64 image return, same shape.

## Implementation

- \`UArborSpawnTools::SpawnText\` (new UFUNCTION) — sets text, world size, color, applies UnlitText override
- \`UArborActorTools::SetMeshMaterial\` (new UFUNCTION) — finds actor's primary mesh component (StaticMesh first, falls back to any \`UMeshComponent\`), validates slot, calls \`SetMaterial\`
- \`bridge/src/registry/actors.ts\` — adds \`spawn_text\` and \`set_mesh_material\` actions
- \`bridge/src/registry/capture.ts\` — \`capture_from_position\` rerouted through Python with file-wait

## Test plan

- [x] TS bridge compiles cleanly
- [ ] Smoke-test \`spawn_text\`: confirm UnlitText default looks right; confirm \`lit: true\` keeps the LIT material
- [ ] Smoke-test \`set_mesh_material\`: place a mesh actor, override slot 0, verify it sticks across save+reopen
- [ ] Smoke-test \`capture_from_position\`: verify image bytes are returned and the file path is real