### PR TITLE
Add UMG widget authoring + preset animation MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,6 +549,40 @@ setup_anim(asset_path, blendspace_path, variable_bindings=[
 
 ---
 
+## Widget Editing (UMG)
+
+> Experimental: enable Project Settings -> Plugins -> Arbor -> Experimental Features -> "Widget (UMG)", then restart the bridge. New UFUNCTIONs (`UWidgetBlueprintBuilder`, `UWidgetAnimationBuilder`) require a full editor restart after first compile (Live Coding cannot register new UFUNCTIONs).
+
+MCP: `ue5_widget(action="create"|"query"|"add_widget"|"remove_widget"|"set_widget_property"|"set_root"|"list_widget_types"|"compile")`.
+
+Authoring goes through C++ builders (UMG/UMGEditor APIs), never raw `unreal` `set_editor_property` on the WidgetTree/CDO (the hard rule applies here too). Builders update in place and never delete-recreate, so references survive.
+
+**Widget tree**: lives on `UWidgetBlueprint::WidgetTree`. `create` builds a WidgetBlueprint subclass of any `UUserWidget`/`UCommonActivatableWidget` (resolve `parent_class` by short name or `/Script/...` path) and can build the whole tree in one call via a `tree` array. Each widget spec: `{name, type, parent?, root?, is_variable?, properties?, slot_properties?}`. List parents before children. Discover types with `list_widget_types` - never guess class names.
+
+**BindWidget is the whole point**: for a C++ `UPROPERTY(meta=(BindWidget)) UTextBlock* Foo;` to bind, the UMG widget must be named **exactly** `Foo` and be a variable (default `is_variable: true`). `query` reports the parent class's `BindWidget`/`BindWidgetOptional` properties (name + type + optional) so you know which names to use; mismatches make `compile` throw "A required widget binding is missing" (surfaced verbatim).
+
+**Brush images / textures**: `set_widget_property` accepts a brush spec, e.g. `{"Brush":{"image":"/Game/UI/T_Panel","draw_as":"Box","image_size":{"x":256,"y":64},"tint":{"r":1,"g":1,"b":1,"a":1},"margin":{"left":12,"top":12,"right":12,"bottom":12}}}`. Use `draw_as:"Box"` (9-slice) for panel backgrounds, `"Image"` for icons. Slot fields go under `{"__slot":{...}}` or `slot_properties` on add_widget.
+
+**Event graph is reused, not duplicated**: a WidgetBlueprint IS-A UBlueprint, so wire `ShowTracker -> PlayAnimation`, `UpdateObjective -> SetText/SetPercent`, etc. via the existing `ue5_blueprint` `add_node`/`connect`/`compile` pointed at the widget asset path. The animation variable name (see below) is the `VariableGet` to feed `PlayAnimation`'s `InAnimation` pin.
+
+### Widget Animations
+
+MCP: `ue5_widget_animation(action="add_preset"|"query"|"remove"|"add_track")`.
+
+Preset-driven, so you get good motion without hand-keying. One animation `name` holds one or more tracks (so `Intro` = fade_in + slide_in plays together). After authoring, the blueprint recompiles and the animation surfaces as a `UWidgetAnimation*` variable you reference from the event graph.
+
+`add_preset` spec: `{ name, tracks: [ { preset, target, duration?, direction?, distance?, overshoot? } ] }`.
+
+| preset | effect | key params (defaults) |
+|--------|--------|-----------------------|
+| `fade_in` / `fade_out` | RenderOpacity 0->1 / 1->0 | duration (0.35 / 0.25) |
+| `slide_in` / `slide_out` | RenderTransform translation | direction (left/right/top/bottom), distance (120), duration (0.35) |
+| `pop` / `scale_in` | RenderTransform scale 0->1 | overshoot (1.1 for pop), duration (0.3). Pivot defaults to center. |
+| `pulse` | scale 1->peak->1 | overshoot (1.08), duration (0.5). Loop via PlayAnimation NumLoopsToPlay. |
+| `strikeoff` | left-to-right wipe over a text widget | duration (0.4). Auto-creates a `<target>_Strike` Image overlay (best-effort; Overlay/Canvas parent recommended). |
+
+Low-level hatch `add_track`: `{ animation, target, track_type:"float"|"transform2d", property?, duration?, channels:[{component, keys:[{t,v}]}] }`. transform2d components: `TranslationX|TranslationY|ScaleX|ScaleY|Rotation`. Use when a preset is not enough.
+
 ## AI Texture Generation
 
 **`get_material_expressions()` hangs** — never call it. Use Material Instances:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,9 +443,11 @@ All BP operations are now available via MCP `ue5_blueprint(action=...)`. For `ue
 | `Branch` | — | In: `execute`, `Condition` / Out: `then`, `else` |
 | `CastTo` | `class` | In: `execute`, `Object` / Out: `then`, `CastFailed`, `As<Class>` |
 | `Timeline` | `timeline` (name) | In: `Play`, `PlayFromStart`, `Stop`, `Reverse` / Out: `Update`, `Finished`, track pins |
+| `FormatText` | `format` (e.g. `"{cur}/{req}"`) | Out: `Result` (text) + one arg pin per `{placeholder}` |
+| `CreateWidget` | `defaults.Class` (widget class path) | In: `execute`, `Class`, `OwningPlayer` / Out: `then`, `ReturnValue` (+ ExposeOnSpawn pins) |
 | *(any UK2Node class)* | `properties` (opt), `defaults` (opt) | *(resolved at runtime)* |
 
-The `UK2Node_` prefix is optional when specifying node classes.
+The `UK2Node_` prefix is optional when specifying node classes - the builder resolves K2 nodes in any module (BlueprintGraph, UMGEditor, ...) via reflection. `FormatText` generates an argument pin for each `{name}` in its format string; `CreateWidget` surfaces the widget's ExposeOnSpawn pins once `defaults.Class` is set.
 
 **Runtime discovery:** Use `ue5_blueprint(action="list_node_types", filter="Sequence")` to discover available K2Node types. Use `ue5_blueprint(action="list_functions", class_name="KismetMathLibrary")` to list callable functions on a class. Use `ue5_blueprint(action="list_component_types", filter="Mesh")` to discover component types. Don't guess node/function/component names — discover them.
 
@@ -557,7 +559,7 @@ MCP: `ue5_widget(action="create"|"query"|"add_widget"|"remove_widget"|"set_widge
 
 Authoring goes through C++ builders (UMG/UMGEditor APIs), never raw `unreal` `set_editor_property` on the WidgetTree/CDO (the hard rule applies here too). Builders update in place and never delete-recreate, so references survive.
 
-**Widget tree**: lives on `UWidgetBlueprint::WidgetTree`. `create` builds a WidgetBlueprint subclass of any `UUserWidget`/`UCommonActivatableWidget` (resolve `parent_class` by short name or `/Script/...` path) and can build the whole tree in one call via a `tree` array. Each widget spec: `{name, type, parent?, root?, is_variable?, properties?, slot_properties?}`. List parents before children. Discover types with `list_widget_types` - never guess class names.
+**Widget tree**: lives on `UWidgetBlueprint::WidgetTree`. `create` builds a WidgetBlueprint subclass of any `UUserWidget`/`UCommonActivatableWidget` (resolve `parent_class` by short name or `/Script/...` path) and can build the whole tree in one call via a `tree` array. Each widget spec: `{name, type, parent?, root?, index?, is_variable?, properties?, slot_properties?}`. List parents before children. `index` (optional) sets the child's slot order within its parent panel (appended then shifted) - use it to control overlay/box z-ordering. Discover types with `list_widget_types` - never guess class names.
 
 **BindWidget is the whole point**: for a C++ `UPROPERTY(meta=(BindWidget)) UTextBlock* Foo;` to bind, the UMG widget must be named **exactly** `Foo` and be a variable (default `is_variable: true`). `query` reports the parent class's `BindWidget`/`BindWidgetOptional` properties (name + type + optional) so you know which names to use; mismatches make `compile` throw "A required widget binding is missing" (surfaced verbatim).
 

--- a/Source/Arbor/Arbor.Build.cs
+++ b/Source/Arbor/Arbor.Build.cs
@@ -56,7 +56,11 @@ public class Arbor : ModuleRules
 			"DeveloperSettings",
 			"Settings",
 			"GraphEditor",
-			"ContentBrowser"
+			"ContentBrowser",
+			"UMG",
+			"UMGEditor",
+			"MovieScene",
+			"MovieSceneTracks"
 		});
 	}
 }

--- a/Source/Arbor/Private/ArborSettings.cpp
+++ b/Source/Arbor/Private/ArborSettings.cpp
@@ -13,13 +13,15 @@ FString UArborSettings::GetEnabledFeaturesJson() const
 		TEXT("\"concept_art_studio\":%s,")
 		TEXT("\"environment\":%s,")
 		TEXT("\"anchors\":%s,")
-		TEXT("\"pcg\":%s")
+		TEXT("\"pcg\":%s,")
+		TEXT("\"widget\":%s")
 		TEXT("}"),
 		bEnableExperimentalFeatures ? TEXT("true") : TEXT("false"),
 		bEnableCodex                ? TEXT("true") : TEXT("false"),
 		bEnableConceptArtStudio     ? TEXT("true") : TEXT("false"),
 		bEnableEnvironment          ? TEXT("true") : TEXT("false"),
 		bEnableAnchors              ? TEXT("true") : TEXT("false"),
-		bEnablePCG                  ? TEXT("true") : TEXT("false")
+		bEnablePCG                  ? TEXT("true") : TEXT("false"),
+		bEnableWidget               ? TEXT("true") : TEXT("false")
 	);
 }

--- a/Source/Arbor/Private/BlueprintBuilder.cpp
+++ b/Source/Arbor/Private/BlueprintBuilder.cpp
@@ -52,6 +52,7 @@
 #include "K2Node_Timeline.h"
 #include "K2Node_Event.h"
 #include "K2Node_DynamicCast.h"
+#include "K2Node_FormatText.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraphSchema_K2.h"
 #include "Kismet2/BlueprintEditorUtils.h"
@@ -1915,6 +1916,26 @@ UEdGraphNode* UBlueprintBuilder::CreateNodeFromJson(
 	{
 		Node = CreateCastNode(Blueprint, Graph, NodeJson, PosX, PosY);
 	}
+	else if (NodeType == TEXT("FormatText"))
+	{
+		// UK2Node_FormatText generates one argument pin per {placeholder} in the format string,
+		// so set the Format text and let the node regenerate its arg pins.
+		UK2Node_FormatText* FmtNode = NewObject<UK2Node_FormatText>(Graph);
+		Graph->AddNode(FmtNode, false, false);
+		FmtNode->AllocateDefaultPins();
+		FmtNode->NodePosX = PosX;
+		FmtNode->NodePosY = PosY;
+		FString Format;
+		if (NodeJson->TryGetStringField(TEXT("format"), Format))
+		{
+			if (UEdGraphPin* FormatPin = FmtNode->GetFormatPin())
+			{
+				FormatPin->DefaultTextValue = FText::FromString(Format);
+				FmtNode->PinDefaultValueChanged(FormatPin);
+			}
+		}
+		Node = FmtNode;
+	}
 	else
 	{
 		// Generic fallback: treat type as a UE5 class name (e.g. "UK2Node_ExecutionSequence")
@@ -2633,9 +2654,24 @@ UEdGraphNode* UBlueprintBuilder::CreateGenericNode(
 	const FString& NodeType,
 	int32 PosX, int32 PosY)
 {
-	// Resolve the node class by name. Try as-is first, then with UK2Node_ prefix.
+	// Resolve the node class by name. TryFindTypeSlow finds already-loaded native classes in
+	// ANY module (BlueprintGraph, UMGEditor, ...) - StaticLoadClass misses compiled-in classes,
+	// which is why editor K2Nodes like UK2Node_CreateWidget previously failed to resolve.
 	FString ClassName = NodeType;
-	UClass* NodeClass = FindObject<UClass>(static_cast<UObject*>(nullptr), *ClassName);
+	UClass* NodeClass = UClass::TryFindTypeSlow<UClass>(ClassName);
+	if (!NodeClass && !ClassName.StartsWith(TEXT("K2Node_")) && !ClassName.StartsWith(TEXT("UK2Node_")))
+	{
+		// Reflected class names drop the U prefix, so K2 nodes register as "K2Node_<X>".
+		NodeClass = UClass::TryFindTypeSlow<UClass>(TEXT("K2Node_") + ClassName);
+		if (!NodeClass)
+		{
+			NodeClass = UClass::TryFindTypeSlow<UClass>(TEXT("UK2Node_") + ClassName);
+		}
+	}
+	if (!NodeClass)
+	{
+		NodeClass = FindObject<UClass>(static_cast<UObject*>(nullptr), *ClassName);
+	}
 
 	if (!NodeClass)
 	{
@@ -2721,6 +2757,16 @@ UEdGraphNode* UBlueprintBuilder::CreateGenericNode(
 					TEXT("Generic node '%s': pin '%s' not found"),
 					*NodeType, *Pair.Key);
 			}
+		}
+	}
+
+	// Construct-from-class nodes (e.g. UK2Node_CreateWidget) expose extra pins once their
+	// Class pin is set - nudge them to regenerate now that defaults are applied.
+	if (UEdGraphPin* ClassPin = Node->FindPin(TEXT("Class")))
+	{
+		if (ClassPin->DefaultObject != nullptr)
+		{
+			Node->PinDefaultValueChanged(ClassPin);
 		}
 	}
 
@@ -3628,8 +3674,10 @@ FString UBlueprintBuilder::GetNodePins(const FString& NodeJsonString, const FStr
 		bCreatedTransientBP = true;
 	}
 
-	// Create a transient graph for the temporary node
-	UEdGraph* TempGraph = NewObject<UEdGraph>(GetTransientPackage(), NAME_None, RF_Transient);
+	// Create a transient graph for the temporary node. Parent it to the Blueprint (not the
+	// transient package) so nodes can resolve GetBlueprint() during AllocateDefaultPins -
+	// member-function nodes on UMG/other classes dereference it and crash if it's null.
+	UEdGraph* TempGraph = NewObject<UEdGraph>(Blueprint, NAME_None, RF_Transient);
 	TempGraph->Schema = UEdGraphSchema_K2::StaticClass();
 
 	// Create the node using existing infrastructure

--- a/Source/Arbor/Private/WidgetAnimationBuilder.cpp
+++ b/Source/Arbor/Private/WidgetAnimationBuilder.cpp
@@ -1,0 +1,537 @@
+#include "WidgetAnimationBuilder.h"
+#include "WidgetBlueprintBuilder.h"
+
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Dom/JsonObject.h"
+
+#include "WidgetBlueprint.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
+#include "Components/PanelWidget.h"
+#include "Components/Image.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+
+#include "Animation/WidgetAnimation.h"
+#include "Animation/WidgetAnimationBinding.h"
+#include "Animation/MovieScene2DTransformTrack.h"
+#include "Animation/MovieScene2DTransformSection.h"
+
+#include "MovieScene.h"
+#include "Tracks/MovieSceneFloatTrack.h"
+#include "Sections/MovieSceneFloatSection.h"
+#include "Channels/MovieSceneFloatChannel.h"
+
+#include "Styling/SlateBrush.h"
+#include "Styling/SlateColor.h"
+
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "EditorAssetLibrary.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogArborWidgetAnim, Log, All);
+
+namespace
+{
+	FString SerializeJson(const TSharedRef<FJsonObject>& Obj)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Obj, Writer);
+		return Out;
+	}
+
+	TSharedPtr<FJsonObject> ParseJson(const FString& JsonString)
+	{
+		TSharedPtr<FJsonObject> Root;
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+		FJsonSerializer::Deserialize(Reader, Root);
+		return Root;
+	}
+
+	// Standard Sequencer tick resolution and a 60fps display rate.
+	const FFrameRate GTickRate(24000, 1);
+	const FFrameRate GDisplayRate(60, 1);
+
+	FFrameNumber FrameAt(float Seconds)
+	{
+		return GTickRate.AsFrameNumber((double)Seconds);
+	}
+}
+
+FString UWidgetAnimationBuilder::MakeError(const FString& Message)
+{
+	TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetBoolField(TEXT("success"), false);
+	Obj->SetStringField(TEXT("error"), Message);
+	UE_LOG(LogArborWidgetAnim, Warning, TEXT("WidgetAnimBuilder error: %s"), *Message);
+	return SerializeJson(Obj);
+}
+
+// ============================================================================
+// Animation + binding helpers
+// ============================================================================
+
+UWidgetAnimation* UWidgetAnimationBuilder::CreateOrGetAnimation(UWidgetBlueprint* WBP, FName AnimName)
+{
+	for (UWidgetAnimation* A : WBP->Animations)
+	{
+		if (A && A->GetFName() == AnimName) return A;
+	}
+
+	UWidgetAnimation* Anim = NewObject<UWidgetAnimation>(WBP, AnimName, RF_Transactional);
+	Anim->MovieScene = NewObject<UMovieScene>(Anim, AnimName, RF_Transactional);
+	Anim->MovieScene->SetTickResolutionDirectly(GTickRate);
+	Anim->MovieScene->SetDisplayRate(GDisplayRate);
+#if WITH_EDITOR
+	Anim->SetDisplayLabel(AnimName.ToString());
+#endif
+	WBP->Animations.Add(Anim);
+	return Anim;
+}
+
+FGuid UWidgetAnimationBuilder::BindWidget(UWidgetAnimation* Anim, UWidgetBlueprint* WBP, const FString& WidgetName)
+{
+	UWidget* W = WBP->WidgetTree->FindWidget(FName(*WidgetName));
+	if (!W) return FGuid();
+
+	for (const FWidgetAnimationBinding& B : Anim->AnimationBindings)
+	{
+		if (B.WidgetName == W->GetFName()) return B.AnimationGuid;
+	}
+
+	const FGuid Guid = Anim->MovieScene->AddPossessable(W->GetName(), W->GetClass());
+
+	FWidgetAnimationBinding Binding;
+	Binding.WidgetName = W->GetFName();
+	Binding.AnimationGuid = Guid;
+	Binding.bIsRootWidget = (W == WBP->WidgetTree->RootWidget);
+	Anim->AnimationBindings.Add(Binding);
+	return Guid;
+}
+
+void UWidgetAnimationBuilder::AddFloatTrack(UMovieScene* MS, const FGuid& Guid, const FString& PropertyName,
+	float StartVal, float EndVal, float Dur)
+{
+	UMovieSceneFloatTrack* Track = MS->AddTrack<UMovieSceneFloatTrack>(Guid);
+	Track->SetPropertyNameAndPath(FName(*PropertyName), PropertyName);
+
+	UMovieSceneFloatSection* Sec = Cast<UMovieSceneFloatSection>(Track->CreateNewSection());
+	Sec->SetRange(TRange<FFrameNumber>(FrameAt(0.f), FrameAt(Dur)));
+	Track->AddSection(*Sec);
+
+	FMovieSceneFloatChannel& Ch = Sec->GetChannel();
+	Ch.AddCubicKey(FrameAt(0.f), StartVal);
+	Ch.AddCubicKey(FrameAt(Dur), EndVal);
+}
+
+UMovieScene2DTransformSection* UWidgetAnimationBuilder::AddTransformSection(UMovieScene* MS, const FGuid& Guid,
+	uint32 ChannelMask, float Dur)
+{
+	UMovieScene2DTransformTrack* Track = MS->AddTrack<UMovieScene2DTransformTrack>(Guid);
+	Track->SetPropertyNameAndPath(FName(TEXT("RenderTransform")), TEXT("RenderTransform"));
+
+	UMovieScene2DTransformSection* Sec = Cast<UMovieScene2DTransformSection>(Track->CreateNewSection());
+	Sec->SetRange(TRange<FFrameNumber>(FrameAt(0.f), FrameAt(Dur)));
+	Sec->SetMask(FMovieScene2DTransformMask((EMovieScene2DTransformChannel)ChannelMask));
+	Track->AddSection(*Sec);
+	return Sec;
+}
+
+// ============================================================================
+// Strikeoff overlay
+// ============================================================================
+
+FString UWidgetAnimationBuilder::CreateStrikeOverlay(UWidgetBlueprint* WBP, const FString& TargetName, FString& OutError)
+{
+	UWidget* Target = WBP->WidgetTree->FindWidget(FName(*TargetName));
+	if (!Target)
+	{
+		OutError = FString::Printf(TEXT("strikeoff target '%s' not found"), *TargetName);
+		return FString();
+	}
+
+	int32 ChildIdx = 0;
+	UPanelWidget* Parent = UWidgetTree::FindWidgetParent(Target, ChildIdx);
+	if (!Parent)
+	{
+		OutError = FString::Printf(TEXT("strikeoff target '%s' has no parent panel"), *TargetName);
+		return FString();
+	}
+
+	const FString StrikeName = TargetName + TEXT("_Strike");
+	if (WBP->WidgetTree->FindWidget(FName(*StrikeName)))
+	{
+		return StrikeName; // already created
+	}
+
+	UImage* Strike = WBP->WidgetTree->ConstructWidget<UImage>(UImage::StaticClass(), FName(*StrikeName));
+	Strike->bIsVariable = true;
+
+	// Thin solid bar (RoundedBox renders tint as a filled rect without a texture).
+	FSlateBrush Brush;
+	Brush.DrawAs = ESlateBrushDrawType::RoundedBox;
+	Brush.TintColor = FSlateColor(FLinearColor::Black);
+	Brush.SetImageSize(FVector2D(120.f, 3.f));
+	Strike->SetBrush(Brush);
+
+	// Grow from the left: pivot at left-center.
+	Strike->SetRenderTransformPivot(FVector2D(0.f, 0.5f));
+
+	UPanelSlot* Slot = Parent->AddChild(Strike);
+	if (UOverlaySlot* OverlaySlot = Cast<UOverlaySlot>(Slot))
+	{
+		OverlaySlot->SetHorizontalAlignment(HAlign_Fill);
+		OverlaySlot->SetVerticalAlignment(VAlign_Center);
+	}
+
+	WBP->OnVariableAdded(Strike->GetFName());
+	return StrikeName;
+}
+
+// ============================================================================
+// Preset application
+// ============================================================================
+
+bool UWidgetAnimationBuilder::ApplyPreset(UWidgetBlueprint* WBP, UWidgetAnimation* Anim,
+	const TSharedPtr<FJsonObject>& Track, float& OutMaxDur, FString& OutError)
+{
+	FString Preset, Target;
+	if (!Track->TryGetStringField(TEXT("preset"), Preset) || !Track->TryGetStringField(TEXT("target"), Target))
+	{
+		OutError = TEXT("track requires 'preset' and 'target'");
+		return false;
+	}
+
+	double Duration = 0.0;
+	const bool bHasDur = Track->TryGetNumberField(TEXT("duration"), Duration);
+
+	UMovieScene* MS = Anim->MovieScene;
+
+	auto Track2 = [&](float D) { OutMaxDur = FMath::Max(OutMaxDur, D); };
+
+	if (Preset.Equals(TEXT("fade_in"), ESearchCase::IgnoreCase))
+	{
+		const float D = bHasDur ? (float)Duration : 0.35f;
+		FGuid Guid = BindWidget(Anim, WBP, Target);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("target '%s' not found"), *Target); return false; }
+		AddFloatTrack(MS, Guid, TEXT("RenderOpacity"), 0.f, 1.f, D);
+		Track2(D);
+		return true;
+	}
+	if (Preset.Equals(TEXT("fade_out"), ESearchCase::IgnoreCase))
+	{
+		const float D = bHasDur ? (float)Duration : 0.25f;
+		FGuid Guid = BindWidget(Anim, WBP, Target);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("target '%s' not found"), *Target); return false; }
+		AddFloatTrack(MS, Guid, TEXT("RenderOpacity"), 1.f, 0.f, D);
+		Track2(D);
+		return true;
+	}
+	if (Preset.Equals(TEXT("slide_in"), ESearchCase::IgnoreCase) || Preset.Equals(TEXT("slide_out"), ESearchCase::IgnoreCase))
+	{
+		const bool bIn = Preset.Equals(TEXT("slide_in"), ESearchCase::IgnoreCase);
+		const float D = bHasDur ? (float)Duration : 0.35f;
+		double Distance = 120.0;
+		Track->TryGetNumberField(TEXT("distance"), Distance);
+		FString Dir = TEXT("bottom");
+		Track->TryGetStringField(TEXT("direction"), Dir);
+
+		FVector2D Offset(0, 0);
+		if (Dir.Equals(TEXT("left"), ESearchCase::IgnoreCase)) Offset = FVector2D(-Distance, 0);
+		else if (Dir.Equals(TEXT("right"), ESearchCase::IgnoreCase)) Offset = FVector2D(Distance, 0);
+		else if (Dir.Equals(TEXT("top"), ESearchCase::IgnoreCase)) Offset = FVector2D(0, -Distance);
+		else Offset = FVector2D(0, Distance); // bottom
+
+		FGuid Guid = BindWidget(Anim, WBP, Target);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("target '%s' not found"), *Target); return false; }
+
+		UMovieScene2DTransformSection* Sec = AddTransformSection(MS, Guid,
+			(uint32)EMovieScene2DTransformChannel::Translation, D);
+
+		const FVector2D Start = bIn ? Offset : FVector2D(0, 0);
+		const FVector2D End = bIn ? FVector2D(0, 0) : Offset;
+		Sec->Translation[0].AddCubicKey(FrameAt(0.f), Start.X);
+		Sec->Translation[0].AddCubicKey(FrameAt(D), End.X);
+		Sec->Translation[1].AddCubicKey(FrameAt(0.f), Start.Y);
+		Sec->Translation[1].AddCubicKey(FrameAt(D), End.Y);
+		Track2(D);
+		return true;
+	}
+	if (Preset.Equals(TEXT("pop"), ESearchCase::IgnoreCase) || Preset.Equals(TEXT("scale_in"), ESearchCase::IgnoreCase))
+	{
+		const float D = bHasDur ? (float)Duration : 0.3f;
+		double Overshoot = Preset.Equals(TEXT("pop"), ESearchCase::IgnoreCase) ? 1.1 : 1.0;
+		Track->TryGetNumberField(TEXT("overshoot"), Overshoot);
+
+		FGuid Guid = BindWidget(Anim, WBP, Target);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("target '%s' not found"), *Target); return false; }
+
+		UMovieScene2DTransformSection* Sec = AddTransformSection(MS, Guid,
+			(uint32)EMovieScene2DTransformChannel::Scale, D);
+
+		for (int32 Axis = 0; Axis < 2; ++Axis)
+		{
+			Sec->Scale[Axis].AddCubicKey(FrameAt(0.f), 0.f);
+			if (Overshoot > 1.0)
+			{
+				Sec->Scale[Axis].AddCubicKey(FrameAt(D * 0.7f), (float)Overshoot);
+			}
+			Sec->Scale[Axis].AddCubicKey(FrameAt(D), 1.f);
+		}
+		Track2(D);
+		return true;
+	}
+	if (Preset.Equals(TEXT("pulse"), ESearchCase::IgnoreCase))
+	{
+		const float D = bHasDur ? (float)Duration : 0.5f;
+		double Peak = 1.08;
+		Track->TryGetNumberField(TEXT("overshoot"), Peak);
+
+		FGuid Guid = BindWidget(Anim, WBP, Target);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("target '%s' not found"), *Target); return false; }
+
+		UMovieScene2DTransformSection* Sec = AddTransformSection(MS, Guid,
+			(uint32)EMovieScene2DTransformChannel::Scale, D);
+		for (int32 Axis = 0; Axis < 2; ++Axis)
+		{
+			Sec->Scale[Axis].AddCubicKey(FrameAt(0.f), 1.f);
+			Sec->Scale[Axis].AddCubicKey(FrameAt(D * 0.5f), (float)Peak);
+			Sec->Scale[Axis].AddCubicKey(FrameAt(D), 1.f);
+		}
+		Track2(D);
+		return true;
+	}
+	if (Preset.Equals(TEXT("strikeoff"), ESearchCase::IgnoreCase))
+	{
+		const float D = bHasDur ? (float)Duration : 0.4f;
+		const FString StrikeName = CreateStrikeOverlay(WBP, Target, OutError);
+		if (StrikeName.IsEmpty()) return false;
+
+		FGuid Guid = BindWidget(Anim, WBP, StrikeName);
+		if (!Guid.IsValid()) { OutError = FString::Printf(TEXT("strike overlay '%s' binding failed"), *StrikeName); return false; }
+
+		UMovieScene2DTransformSection* Sec = AddTransformSection(MS, Guid,
+			(uint32)EMovieScene2DTransformChannel::ScaleX, D);
+		Sec->Scale[0].AddCubicKey(FrameAt(0.f), 0.f);
+		Sec->Scale[0].AddCubicKey(FrameAt(D), 1.f);
+		// keep Y at 1 so the bar retains its thickness
+		Sec->Scale[1].AddCubicKey(FrameAt(0.f), 1.f);
+		Track2(D);
+		return true;
+	}
+
+	OutError = FString::Printf(TEXT("unknown preset '%s'"), *Preset);
+	return false;
+}
+
+void UWidgetAnimationBuilder::RecompileAndSave(UWidgetBlueprint* WBP)
+{
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	FKismetEditorUtilities::CompileBlueprint(WBP);
+	UEditorAssetLibrary::SaveLoadedAsset(WBP, false);
+}
+
+// ============================================================================
+// Public UFUNCTIONs
+// ============================================================================
+
+FString UWidgetAnimationBuilder::AddAnimationFromPreset(const FString& AssetPath, const FString& PresetJsonString)
+{
+	UWidgetBlueprint* WBP = UWidgetBlueprintBuilder::LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	TSharedPtr<FJsonObject> Root = ParseJson(PresetJsonString);
+	if (!Root.IsValid()) return MakeError(TEXT("invalid JSON"));
+
+	FString Name;
+	if (!Root->TryGetStringField(TEXT("name"), Name)) return MakeError(TEXT("'name' required"));
+
+	const TArray<TSharedPtr<FJsonValue>>* Tracks;
+	if (!Root->TryGetArrayField(TEXT("tracks"), Tracks) || Tracks->Num() == 0)
+		return MakeError(TEXT("'tracks' array required"));
+
+	UWidgetAnimation* Anim = CreateOrGetAnimation(WBP, FName(*Name));
+
+	float MaxDur = 0.f;
+	for (const TSharedPtr<FJsonValue>& V : *Tracks)
+	{
+		const TSharedPtr<FJsonObject>& TrackObj = V->AsObject();
+		if (!TrackObj.IsValid()) continue;
+		FString Err;
+		if (!ApplyPreset(WBP, Anim, TrackObj, MaxDur, Err))
+		{
+			return MakeError(Err);
+		}
+	}
+
+	if (MaxDur <= 0.f) MaxDur = 0.35f;
+	Anim->MovieScene->SetPlaybackRange(TRange<FFrameNumber>(FFrameNumber(0), FrameAt(MaxDur)), true);
+
+	RecompileAndSave(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("animation"), Name);
+	Result->SetNumberField(TEXT("duration"), MaxDur);
+	return SerializeJson(Result);
+}
+
+FString UWidgetAnimationBuilder::QueryAnimations(const FString& AssetPath)
+{
+	UWidgetBlueprint* WBP = UWidgetBlueprintBuilder::LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	TArray<TSharedPtr<FJsonValue>> Anims;
+	for (UWidgetAnimation* A : WBP->Animations)
+	{
+		if (!A) continue;
+		TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("name"), A->GetName());
+		Entry->SetNumberField(TEXT("end_time"), A->GetEndTime());
+
+		TArray<TSharedPtr<FJsonValue>> Bindings;
+		for (const FWidgetAnimationBinding& B : A->AnimationBindings)
+		{
+			TSharedRef<FJsonObject> BObj = MakeShared<FJsonObject>();
+			BObj->SetStringField(TEXT("widget"), B.WidgetName.ToString());
+			BObj->SetStringField(TEXT("guid"), B.AnimationGuid.ToString());
+			Bindings.Add(MakeShared<FJsonValueObject>(BObj));
+		}
+		Entry->SetArrayField(TEXT("bindings"), Bindings);
+		Entry->SetNumberField(TEXT("binding_count"), A->AnimationBindings.Num());
+		Anims.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetArrayField(TEXT("animations"), Anims);
+	return SerializeJson(Result);
+}
+
+FString UWidgetAnimationBuilder::RemoveAnimation(const FString& AssetPath, const FString& AnimationName)
+{
+	UWidgetBlueprint* WBP = UWidgetBlueprintBuilder::LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	int32 RemovedIdx = INDEX_NONE;
+	for (int32 i = 0; i < WBP->Animations.Num(); ++i)
+	{
+		if (WBP->Animations[i] && WBP->Animations[i]->GetName() == AnimationName)
+		{
+			RemovedIdx = i;
+			break;
+		}
+	}
+	if (RemovedIdx == INDEX_NONE) return MakeError(FString::Printf(TEXT("animation '%s' not found"), *AnimationName));
+
+	WBP->Animations.RemoveAt(RemovedIdx);
+	RecompileAndSave(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	return SerializeJson(Result);
+}
+
+FString UWidgetAnimationBuilder::AddAnimationTrack(const FString& AssetPath, const FString& TrackJsonString)
+{
+	UWidgetBlueprint* WBP = UWidgetBlueprintBuilder::LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	TSharedPtr<FJsonObject> Root = ParseJson(TrackJsonString);
+	if (!Root.IsValid()) return MakeError(TEXT("invalid JSON"));
+
+	FString AnimName, Target, TrackType;
+	if (!Root->TryGetStringField(TEXT("animation"), AnimName) ||
+		!Root->TryGetStringField(TEXT("target"), Target) ||
+		!Root->TryGetStringField(TEXT("track_type"), TrackType))
+	{
+		return MakeError(TEXT("'animation', 'target', 'track_type' required"));
+	}
+
+	double Duration = 1.0;
+	Root->TryGetNumberField(TEXT("duration"), Duration);
+
+	UWidgetAnimation* Anim = CreateOrGetAnimation(WBP, FName(*AnimName));
+	FGuid Guid = BindWidget(Anim, WBP, Target);
+	if (!Guid.IsValid()) return MakeError(FString::Printf(TEXT("target '%s' not found"), *Target));
+
+	UMovieScene* MS = Anim->MovieScene;
+
+	const TArray<TSharedPtr<FJsonValue>>* Channels;
+	if (!Root->TryGetArrayField(TEXT("channels"), Channels))
+		return MakeError(TEXT("'channels' array required"));
+
+	if (TrackType.Equals(TEXT("float"), ESearchCase::IgnoreCase))
+	{
+		FString Property = TEXT("RenderOpacity");
+		Root->TryGetStringField(TEXT("property"), Property);
+		UMovieSceneFloatTrack* Track = MS->AddTrack<UMovieSceneFloatTrack>(Guid);
+		Track->SetPropertyNameAndPath(FName(*Property), Property);
+		UMovieSceneFloatSection* Sec = Cast<UMovieSceneFloatSection>(Track->CreateNewSection());
+		Sec->SetRange(TRange<FFrameNumber>(FrameAt(0.f), FrameAt((float)Duration)));
+		Track->AddSection(*Sec);
+		FMovieSceneFloatChannel& Ch = Sec->GetChannel();
+		const TSharedPtr<FJsonObject>& Ch0 = (*Channels)[0]->AsObject();
+		const TArray<TSharedPtr<FJsonValue>>* Keys;
+		if (Ch0.IsValid() && Ch0->TryGetArrayField(TEXT("keys"), Keys))
+		{
+			for (const TSharedPtr<FJsonValue>& K : *Keys)
+			{
+				const TSharedPtr<FJsonObject>& KO = K->AsObject();
+				if (!KO.IsValid()) continue;
+				double T = 0, Val = 0;
+				KO->TryGetNumberField(TEXT("t"), T);
+				KO->TryGetNumberField(TEXT("v"), Val);
+				Ch.AddCubicKey(FrameAt((float)T), (float)Val);
+			}
+		}
+	}
+	else if (TrackType.Equals(TEXT("transform2d"), ESearchCase::IgnoreCase))
+	{
+		UMovieScene2DTransformSection* Sec = AddTransformSection(MS, Guid,
+			(uint32)EMovieScene2DTransformChannel::AllTransform, (float)Duration);
+		for (const TSharedPtr<FJsonValue>& CV : *Channels)
+		{
+			const TSharedPtr<FJsonObject>& CO = CV->AsObject();
+			if (!CO.IsValid()) continue;
+			FString Component;
+			CO->TryGetStringField(TEXT("component"), Component);
+			FMovieSceneFloatChannel* Ch = nullptr;
+			if (Component.Equals(TEXT("TranslationX"), ESearchCase::IgnoreCase)) Ch = &Sec->Translation[0];
+			else if (Component.Equals(TEXT("TranslationY"), ESearchCase::IgnoreCase)) Ch = &Sec->Translation[1];
+			else if (Component.Equals(TEXT("ScaleX"), ESearchCase::IgnoreCase)) Ch = &Sec->Scale[0];
+			else if (Component.Equals(TEXT("ScaleY"), ESearchCase::IgnoreCase)) Ch = &Sec->Scale[1];
+			else if (Component.Equals(TEXT("Rotation"), ESearchCase::IgnoreCase)) Ch = &Sec->Rotation;
+			if (!Ch) continue;
+
+			const TArray<TSharedPtr<FJsonValue>>* Keys;
+			if (CO->TryGetArrayField(TEXT("keys"), Keys))
+			{
+				for (const TSharedPtr<FJsonValue>& K : *Keys)
+				{
+					const TSharedPtr<FJsonObject>& KO = K->AsObject();
+					if (!KO.IsValid()) continue;
+					double T = 0, Val = 0;
+					KO->TryGetNumberField(TEXT("t"), T);
+					KO->TryGetNumberField(TEXT("v"), Val);
+					Ch->AddCubicKey(FrameAt((float)T), (float)Val);
+				}
+			}
+		}
+	}
+	else
+	{
+		return MakeError(FString::Printf(TEXT("unknown track_type '%s'"), *TrackType));
+	}
+
+	Anim->MovieScene->SetPlaybackRange(TRange<FFrameNumber>(FFrameNumber(0), FrameAt((float)Duration)), true);
+	RecompileAndSave(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("animation"), AnimName);
+	return SerializeJson(Result);
+}

--- a/Source/Arbor/Private/WidgetBlueprintBuilder.cpp
+++ b/Source/Arbor/Private/WidgetBlueprintBuilder.cpp
@@ -399,6 +399,15 @@ UWidget* UWidgetBlueprintBuilder::CreateWidgetFromSpec(UWidgetBlueprint* WBP, co
 			return nullptr;
 		}
 		UPanelSlot* Slot = Panel->AddChild(W);
+
+		// Optional explicit child index (AddChild appends; ShiftChild moves it). Lets callers
+		// control panel/overlay ordering, e.g. inserting a layer stack before another.
+		int32 ChildIndex = INDEX_NONE;
+		if (Spec->TryGetNumberField(TEXT("index"), ChildIndex) && ChildIndex >= 0)
+		{
+			Panel->ShiftChild(ChildIndex, W);
+		}
+
 		const TSharedPtr<FJsonObject>* SlotProps;
 		if (Slot && Spec->TryGetObjectField(TEXT("slot_properties"), SlotProps))
 		{

--- a/Source/Arbor/Private/WidgetBlueprintBuilder.cpp
+++ b/Source/Arbor/Private/WidgetBlueprintBuilder.cpp
@@ -1,0 +1,726 @@
+#include "WidgetBlueprintBuilder.h"
+
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Dom/JsonObject.h"
+
+#include "WidgetBlueprint.h"
+#include "Blueprint/WidgetTree.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetBlueprintGeneratedClass.h"
+#include "Components/Widget.h"
+#include "Components/PanelWidget.h"
+#include "Components/PanelSlot.h"
+#include "Animation/WidgetAnimation.h"
+
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/CompilerResultsLog.h"
+
+#include "Styling/SlateBrush.h"
+#include "Styling/SlateColor.h"
+#include "Engine/Texture2D.h"
+
+#include "UObject/Package.h"
+#include "UObject/UnrealType.h"
+#include "UObject/UObjectIterator.h"
+#include "UObject/Field.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "EditorAssetLibrary.h"
+#include "Misc/Paths.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogArborWidget, Log, All);
+
+// ============================================================================
+// Small JSON helpers
+// ============================================================================
+
+namespace
+{
+	FString SerializeJson(const TSharedRef<FJsonObject>& Obj)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Obj, Writer);
+		return Out;
+	}
+
+	TSharedPtr<FJsonObject> ParseJson(const FString& JsonString)
+	{
+		TSharedPtr<FJsonObject> Root;
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+		FJsonSerializer::Deserialize(Reader, Root);
+		return Root;
+	}
+
+	/** Find a loaded UClass derived from BaseClass by short or U-prefixed name. */
+	UClass* FindClassByShortName(const FString& Name, UClass* BaseClass)
+	{
+		const FString UName = Name.StartsWith(TEXT("U")) ? Name : (TEXT("U") + Name);
+		for (TObjectIterator<UClass> It; It; ++It)
+		{
+			UClass* C = *It;
+			if (!C->IsChildOf(BaseClass)) continue;
+			if (C->GetName() == Name || C->GetName() == UName)
+			{
+				return C;
+			}
+		}
+		return nullptr;
+	}
+
+	/** Resolve a class by full path (/Script/Module.Class or /Game/BP.BP_C) or short name. */
+	UClass* ResolveClassLenient(const FString& Spec, UClass* BaseClass)
+	{
+		if (Spec.IsEmpty()) return nullptr;
+
+		if (Spec.StartsWith(TEXT("/")))
+		{
+			if (UClass* Loaded = LoadObject<UClass>(nullptr, *Spec))
+			{
+				if (Loaded->IsChildOf(BaseClass)) return Loaded;
+			}
+			if (!Spec.EndsWith(TEXT("_C")))
+			{
+				const FString WithC = Spec + TEXT("_C");
+				if (UClass* Loaded = LoadObject<UClass>(nullptr, *WithC))
+				{
+					if (Loaded->IsChildOf(BaseClass)) return Loaded;
+				}
+			}
+			return nullptr;
+		}
+		return FindClassByShortName(Spec, BaseClass);
+	}
+}
+
+FString UWidgetBlueprintBuilder::MakeError(const FString& Message)
+{
+	TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetBoolField(TEXT("success"), false);
+	Obj->SetStringField(TEXT("error"), Message);
+	UE_LOG(LogArborWidget, Warning, TEXT("WidgetBuilder error: %s"), *Message);
+	return SerializeJson(Obj);
+}
+
+// ============================================================================
+// Class resolution
+// ============================================================================
+
+UClass* UWidgetBlueprintBuilder::ResolveParentWidgetClass(const FString& ClassName)
+{
+	UClass* Resolved = ResolveClassLenient(ClassName, UUserWidget::StaticClass());
+	return Resolved ? Resolved : UUserWidget::StaticClass();
+}
+
+UClass* UWidgetBlueprintBuilder::ResolveWidgetClass(const FString& TypeName)
+{
+	return ResolveClassLenient(TypeName, UWidget::StaticClass());
+}
+
+// ============================================================================
+// Generic JSON -> FProperty applier
+// ============================================================================
+
+void UWidgetBlueprintBuilder::ApplyJsonToProperty(FProperty* Prop, void* ValuePtr, const TSharedPtr<FJsonValue>& Json)
+{
+	if (!Prop || !ValuePtr || !Json.IsValid()) return;
+
+	// Bool
+	if (FBoolProperty* BoolP = CastField<FBoolProperty>(Prop))
+	{
+		BoolP->SetPropertyValue(ValuePtr, Json->AsBool());
+		return;
+	}
+	// String / Name / Text
+	if (FStrProperty* StrP = CastField<FStrProperty>(Prop))
+	{
+		StrP->SetPropertyValue(ValuePtr, Json->AsString());
+		return;
+	}
+	if (FNameProperty* NameP = CastField<FNameProperty>(Prop))
+	{
+		NameP->SetPropertyValue(ValuePtr, FName(*Json->AsString()));
+		return;
+	}
+	if (FTextProperty* TextP = CastField<FTextProperty>(Prop))
+	{
+		TextP->SetPropertyValue(ValuePtr, FText::FromString(Json->AsString()));
+		return;
+	}
+	// Enum (FEnumProperty)
+	if (FEnumProperty* EnumP = CastField<FEnumProperty>(Prop))
+	{
+		FNumericProperty* Under = EnumP->GetUnderlyingProperty();
+		FString S;
+		if (Json->TryGetString(S))
+		{
+			UEnum* E = EnumP->GetEnum();
+			int64 V = E ? E->GetValueByNameString(S) : INDEX_NONE;
+			if (V == INDEX_NONE && E) V = E->GetValueByNameString(E->GenerateFullEnumName(*S));
+			if (V != INDEX_NONE) Under->SetIntPropertyValue(ValuePtr, V);
+		}
+		else
+		{
+			Under->SetIntPropertyValue(ValuePtr, (int64)Json->AsNumber());
+		}
+		return;
+	}
+	// Byte (possibly enum-backed)
+	if (FByteProperty* ByteP = CastField<FByteProperty>(Prop))
+	{
+		FString S;
+		if (ByteP->Enum && Json->TryGetString(S))
+		{
+			int64 V = ByteP->Enum->GetValueByNameString(S);
+			if (V == INDEX_NONE) V = ByteP->Enum->GetValueByNameString(ByteP->Enum->GenerateFullEnumName(*S));
+			if (V != INDEX_NONE) ByteP->SetIntPropertyValue(ValuePtr, V);
+		}
+		else
+		{
+			ByteP->SetIntPropertyValue(ValuePtr, (int64)Json->AsNumber());
+		}
+		return;
+	}
+	// Object / Class
+	if (FObjectPropertyBase* ObjP = CastField<FObjectPropertyBase>(Prop))
+	{
+		FString Path;
+		if (Json->TryGetString(Path) && !Path.IsEmpty())
+		{
+			if (CastField<FClassProperty>(Prop) || CastField<FSoftClassProperty>(Prop))
+			{
+				if (UClass* C = ResolveClassLenient(Path, UObject::StaticClass()))
+				{
+					ObjP->SetObjectPropertyValue(ValuePtr, C);
+				}
+			}
+			else if (UObject* Loaded = LoadObject<UObject>(nullptr, *Path))
+			{
+				ObjP->SetObjectPropertyValue(ValuePtr, Loaded);
+			}
+		}
+		return;
+	}
+	// Struct (recurse; FSlateBrush special-cased)
+	if (FStructProperty* SP = CastField<FStructProperty>(Prop))
+	{
+		UScriptStruct* SS = SP->Struct;
+		if (SS && SS->GetName() == TEXT("SlateBrush"))
+		{
+			FSlateBrush* Brush = static_cast<FSlateBrush*>(ValuePtr);
+			const TSharedPtr<FJsonObject>* BObj;
+			if (Json->TryGetObject(BObj))
+			{
+				FString Img;
+				if ((*BObj)->TryGetStringField(TEXT("image"), Img) && !Img.IsEmpty())
+				{
+					if (UTexture2D* Tex = LoadObject<UTexture2D>(nullptr, *Img))
+					{
+						Brush->SetResourceObject(Tex);
+					}
+				}
+				FString DrawAs;
+				if ((*BObj)->TryGetStringField(TEXT("draw_as"), DrawAs))
+				{
+					if (DrawAs.Equals(TEXT("Box"), ESearchCase::IgnoreCase)) Brush->DrawAs = ESlateBrushDrawType::Box;
+					else if (DrawAs.Equals(TEXT("Border"), ESearchCase::IgnoreCase)) Brush->DrawAs = ESlateBrushDrawType::Border;
+					else if (DrawAs.Equals(TEXT("RoundedBox"), ESearchCase::IgnoreCase)) Brush->DrawAs = ESlateBrushDrawType::RoundedBox;
+					else if (DrawAs.Equals(TEXT("NoDrawType"), ESearchCase::IgnoreCase) || DrawAs.Equals(TEXT("None"), ESearchCase::IgnoreCase)) Brush->DrawAs = ESlateBrushDrawType::NoDrawType;
+					else Brush->DrawAs = ESlateBrushDrawType::Image;
+				}
+				const TSharedPtr<FJsonObject>* SizeObj;
+				if ((*BObj)->TryGetObjectField(TEXT("image_size"), SizeObj))
+				{
+					double X = 0, Y = 0;
+					(*SizeObj)->TryGetNumberField(TEXT("x"), X);
+					(*SizeObj)->TryGetNumberField(TEXT("y"), Y);
+					Brush->SetImageSize(FVector2D(X, Y));
+				}
+				const TSharedPtr<FJsonObject>* TintObj;
+				if ((*BObj)->TryGetObjectField(TEXT("tint"), TintObj))
+				{
+					double R = 1, G = 1, B = 1, A = 1;
+					(*TintObj)->TryGetNumberField(TEXT("r"), R);
+					(*TintObj)->TryGetNumberField(TEXT("g"), G);
+					(*TintObj)->TryGetNumberField(TEXT("b"), B);
+					(*TintObj)->TryGetNumberField(TEXT("a"), A);
+					Brush->TintColor = FSlateColor(FLinearColor(R, G, B, A));
+				}
+				const TSharedPtr<FJsonObject>* MarginObj;
+				if ((*BObj)->TryGetObjectField(TEXT("margin"), MarginObj))
+				{
+					double L = 0, T = 0, Rr = 0, Bm = 0;
+					(*MarginObj)->TryGetNumberField(TEXT("left"), L);
+					(*MarginObj)->TryGetNumberField(TEXT("top"), T);
+					(*MarginObj)->TryGetNumberField(TEXT("right"), Rr);
+					(*MarginObj)->TryGetNumberField(TEXT("bottom"), Bm);
+					Brush->Margin = FMargin(L, T, Rr, Bm);
+				}
+			}
+			return;
+		}
+
+		const TSharedPtr<FJsonObject>* Obj;
+		if (Json->TryGetObject(Obj))
+		{
+			for (TFieldIterator<FProperty> It(SS); It; ++It)
+			{
+				FProperty* Member = *It;
+				for (const auto& Pair : (*Obj)->Values)
+				{
+					if (Pair.Key.Equals(Member->GetName(), ESearchCase::IgnoreCase))
+					{
+						ApplyJsonToProperty(Member, Member->ContainerPtrToValuePtr<void>(ValuePtr), Pair.Value);
+						break;
+					}
+				}
+			}
+			return;
+		}
+		FString S;
+		if (Json->TryGetString(S))
+		{
+			Prop->ImportText_Direct(*S, ValuePtr, nullptr, PPF_None);
+		}
+		return;
+	}
+	// Array
+	if (FArrayProperty* ArrP = CastField<FArrayProperty>(Prop))
+	{
+		const TArray<TSharedPtr<FJsonValue>>* Arr;
+		if (Json->TryGetArray(Arr))
+		{
+			FScriptArrayHelper Helper(ArrP, ValuePtr);
+			Helper.Resize(Arr->Num());
+			for (int32 i = 0; i < Arr->Num(); ++i)
+			{
+				ApplyJsonToProperty(ArrP->Inner, Helper.GetRawPtr(i), (*Arr)[i]);
+			}
+		}
+		return;
+	}
+	// Numeric fallback (int/float/double)
+	if (FNumericProperty* NumP = CastField<FNumericProperty>(Prop))
+	{
+		const double N = Json->AsNumber();
+		if (NumP->IsFloatingPoint()) NumP->SetFloatingPointPropertyValue(ValuePtr, N);
+		else NumP->SetIntPropertyValue(ValuePtr, (int64)N);
+		return;
+	}
+	// Last resort: import from string
+	FString S;
+	if (Json->TryGetString(S))
+	{
+		Prop->ImportText_Direct(*S, ValuePtr, nullptr, PPF_None);
+	}
+}
+
+void UWidgetBlueprintBuilder::ApplyProperties(UObject* Target, const TSharedPtr<FJsonObject>& Props)
+{
+	if (!Target || !Props.IsValid()) return;
+
+	for (const auto& Pair : Props->Values)
+	{
+		FProperty* Prop = Target->GetClass()->FindPropertyByName(FName(*Pair.Key));
+		if (!Prop)
+		{
+			// Case-insensitive search fallback
+			for (TFieldIterator<FProperty> It(Target->GetClass()); It; ++It)
+			{
+				if (It->GetName().Equals(Pair.Key, ESearchCase::IgnoreCase)) { Prop = *It; break; }
+			}
+		}
+		if (Prop)
+		{
+			ApplyJsonToProperty(Prop, Prop->ContainerPtrToValuePtr<void>(Target), Pair.Value);
+		}
+		else
+		{
+			UE_LOG(LogArborWidget, Warning, TEXT("Property '%s' not found on %s"), *Pair.Key, *Target->GetClass()->GetName());
+		}
+	}
+}
+
+// ============================================================================
+// Widget creation
+// ============================================================================
+
+UWidget* UWidgetBlueprintBuilder::CreateWidgetFromSpec(UWidgetBlueprint* WBP, const TSharedPtr<FJsonObject>& Spec, FString& OutError)
+{
+	FString Name, Type;
+	if (!Spec->TryGetStringField(TEXT("name"), Name) || !Spec->TryGetStringField(TEXT("type"), Type))
+	{
+		OutError = TEXT("widget spec requires 'name' and 'type'");
+		return nullptr;
+	}
+
+	if (WBP->WidgetTree->FindWidget(FName(*Name)))
+	{
+		OutError = FString::Printf(TEXT("widget '%s' already exists"), *Name);
+		return nullptr;
+	}
+
+	UClass* WidgetClass = ResolveWidgetClass(Type);
+	if (!WidgetClass)
+	{
+		OutError = FString::Printf(TEXT("unknown widget type '%s' (use list_widget_types)"), *Type);
+		return nullptr;
+	}
+
+	UWidget* W = WBP->WidgetTree->ConstructWidget<UWidget>(WidgetClass, FName(*Name));
+	if (!W)
+	{
+		OutError = FString::Printf(TEXT("failed to construct widget '%s'"), *Name);
+		return nullptr;
+	}
+
+	bool bIsVariable = true;
+	Spec->TryGetBoolField(TEXT("is_variable"), bIsVariable);
+	W->bIsVariable = bIsVariable;
+
+	bool bRoot = false;
+	Spec->TryGetBoolField(TEXT("root"), bRoot);
+	FString ParentName;
+	const bool bHasParent = Spec->TryGetStringField(TEXT("parent"), ParentName) && !ParentName.IsEmpty();
+
+	if (bRoot || !bHasParent)
+	{
+		WBP->WidgetTree->RootWidget = W;
+	}
+	else
+	{
+		UWidget* ParentW = WBP->WidgetTree->FindWidget(FName(*ParentName));
+		UPanelWidget* Panel = Cast<UPanelWidget>(ParentW);
+		if (!Panel)
+		{
+			OutError = FString::Printf(TEXT("parent '%s' not found or not a panel widget"), *ParentName);
+			return nullptr;
+		}
+		UPanelSlot* Slot = Panel->AddChild(W);
+		const TSharedPtr<FJsonObject>* SlotProps;
+		if (Slot && Spec->TryGetObjectField(TEXT("slot_properties"), SlotProps))
+		{
+			ApplyProperties(Slot, *SlotProps);
+		}
+	}
+
+	const TSharedPtr<FJsonObject>* Props;
+	if (Spec->TryGetObjectField(TEXT("properties"), Props))
+	{
+		ApplyProperties(W, *Props);
+	}
+
+	if (bIsVariable)
+	{
+		WBP->OnVariableAdded(W->GetFName());
+	}
+
+	return W;
+}
+
+// ============================================================================
+// Asset creation / loading / saving
+// ============================================================================
+
+UWidgetBlueprint* UWidgetBlueprintBuilder::CreateWidgetBlueprintAsset(const FString& Name, const FString& AssetPath, UClass* ParentClass)
+{
+	const FString PackageName = AssetPath / Name;
+	UPackage* Package = CreatePackage(*PackageName);
+	if (!Package) return nullptr;
+
+	UWidgetBlueprint* WBP = Cast<UWidgetBlueprint>(
+		FKismetEditorUtilities::CreateBlueprint(
+			ParentClass, Package, FName(*Name), BPTYPE_Normal,
+			UWidgetBlueprint::StaticClass(), UWidgetBlueprintGeneratedClass::StaticClass()));
+
+	if (!WBP) return nullptr;
+
+	if (!WBP->WidgetTree)
+	{
+		WBP->WidgetTree = NewObject<UWidgetTree>(WBP, TEXT("WidgetTree"), RF_Transactional);
+	}
+
+	FAssetRegistryModule::AssetCreated(WBP);
+	Package->MarkPackageDirty();
+	return WBP;
+}
+
+UWidgetBlueprint* UWidgetBlueprintBuilder::LoadWidgetBlueprint(const FString& AssetPath)
+{
+	UObject* Asset = UEditorAssetLibrary::LoadAsset(AssetPath);
+	return Cast<UWidgetBlueprint>(Asset);
+}
+
+bool UWidgetBlueprintBuilder::SaveAsset(UObject* Asset)
+{
+	if (!Asset) return false;
+	return UEditorAssetLibrary::SaveLoadedAsset(Asset, false);
+}
+
+// ============================================================================
+// BindWidget reporting
+// ============================================================================
+
+TArray<TSharedPtr<FJsonValue>> UWidgetBlueprintBuilder::CollectBindWidgetProperties(UClass* ParentClass)
+{
+	TArray<TSharedPtr<FJsonValue>> Out;
+	if (!ParentClass) return Out;
+
+	for (TFieldIterator<FObjectPropertyBase> It(ParentClass); It; ++It)
+	{
+		FObjectPropertyBase* P = *It;
+		const bool bBind = P->HasMetaData(TEXT("BindWidget"));
+		const bool bOpt = P->HasMetaData(TEXT("BindWidgetOptional"));
+		if (!bBind && !bOpt) continue;
+
+		TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("name"), P->GetName());
+		Entry->SetStringField(TEXT("type"), P->PropertyClass ? P->PropertyClass->GetName() : TEXT("Widget"));
+		Entry->SetBoolField(TEXT("optional"), bOpt);
+		Out.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+	return Out;
+}
+
+// ============================================================================
+// Public UFUNCTIONs
+// ============================================================================
+
+FString UWidgetBlueprintBuilder::BuildWidgetFromJSONString(const FString& JsonString, const FString& AssetPath)
+{
+	TSharedPtr<FJsonObject> Root = ParseJson(JsonString);
+	if (!Root.IsValid()) return MakeError(TEXT("invalid JSON"));
+
+	FString Name, ParentClassName;
+	if (!Root->TryGetStringField(TEXT("name"), Name))
+		return MakeError(TEXT("'name' required"));
+	Root->TryGetStringField(TEXT("parent_class"), ParentClassName);
+
+	FString ContentPath = AssetPath;
+	Root->TryGetStringField(TEXT("content_path"), ContentPath);
+	if (ContentPath.IsEmpty()) ContentPath = TEXT("/Game/UI/Widgets");
+
+	UClass* ParentClass = ResolveParentWidgetClass(ParentClassName);
+
+	const FString FullPath = ContentPath / Name;
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(FullPath);
+	if (!WBP)
+	{
+		WBP = CreateWidgetBlueprintAsset(Name, ContentPath, ParentClass);
+		if (!WBP) return MakeError(FString::Printf(TEXT("failed to create WidgetBlueprint at %s"), *FullPath));
+	}
+
+	// Build the tree (parents must appear before children).
+	const TArray<TSharedPtr<FJsonValue>>* Tree;
+	if (Root->TryGetArrayField(TEXT("tree"), Tree))
+	{
+		for (const TSharedPtr<FJsonValue>& V : *Tree)
+		{
+			const TSharedPtr<FJsonObject>& Spec = V->AsObject();
+			if (!Spec.IsValid()) continue;
+			FString Err;
+			if (!CreateWidgetFromSpec(WBP, Spec, Err))
+			{
+				return MakeError(FString::Printf(TEXT("tree build failed: %s"), *Err));
+			}
+		}
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	FKismetEditorUtilities::CompileBlueprint(WBP);
+	SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("asset_path"), FullPath);
+	Result->SetArrayField(TEXT("bind_widgets"), CollectBindWidgetProperties(ParentClass));
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::QueryWidget(const FString& AssetPath)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("asset_path"), AssetPath);
+
+	// Widget tree
+	TArray<TSharedPtr<FJsonValue>> Widgets;
+	TArray<UWidget*> All;
+	WBP->WidgetTree->GetAllWidgets(All);
+	for (UWidget* W : All)
+	{
+		if (!W) continue;
+		TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("name"), W->GetName());
+		Entry->SetStringField(TEXT("class"), W->GetClass()->GetName());
+		Entry->SetBoolField(TEXT("is_variable"), W->bIsVariable);
+		Entry->SetBoolField(TEXT("is_root"), W == WBP->WidgetTree->RootWidget);
+		int32 ChildIdx = 0;
+		if (UPanelWidget* Parent = UWidgetTree::FindWidgetParent(W, ChildIdx))
+		{
+			Entry->SetStringField(TEXT("parent"), Parent->GetName());
+		}
+		if (W->Slot)
+		{
+			Entry->SetStringField(TEXT("slot"), W->Slot->GetClass()->GetName());
+		}
+		Widgets.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+	Result->SetArrayField(TEXT("widgets"), Widgets);
+
+	// Animations
+	TArray<TSharedPtr<FJsonValue>> Anims;
+	for (UWidgetAnimation* A : WBP->Animations)
+	{
+		if (A) Anims.Add(MakeShared<FJsonValueString>(A->GetName()));
+	}
+	Result->SetArrayField(TEXT("animations"), Anims);
+
+	// BindWidget properties from the parent class
+	UClass* ParentClass = WBP->ParentClass ? WBP->ParentClass.Get() : nullptr;
+	Result->SetArrayField(TEXT("bind_widgets"), CollectBindWidgetProperties(ParentClass));
+
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::AddWidget(const FString& AssetPath, const FString& WidgetJsonString)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	TSharedPtr<FJsonObject> Spec = ParseJson(WidgetJsonString);
+	if (!Spec.IsValid()) return MakeError(TEXT("invalid widget JSON"));
+
+	FString Err;
+	UWidget* W = CreateWidgetFromSpec(WBP, Spec, Err);
+	if (!W) return MakeError(Err);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("widget"), W->GetName());
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::RemoveWidget(const FString& AssetPath, const FString& WidgetName)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	UWidget* W = WBP->WidgetTree->FindWidget(FName(*WidgetName));
+	if (!W) return MakeError(FString::Printf(TEXT("widget '%s' not found"), *WidgetName));
+
+	WBP->WidgetTree->RemoveWidget(W);
+	WBP->OnVariableRemoved(FName(*WidgetName));
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::SetWidgetProperty(const FString& AssetPath, const FString& WidgetName, const FString& PropertyJsonString)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	UWidget* W = WBP->WidgetTree->FindWidget(FName(*WidgetName));
+	if (!W) return MakeError(FString::Printf(TEXT("widget '%s' not found"), *WidgetName));
+
+	TSharedPtr<FJsonObject> Props = ParseJson(PropertyJsonString);
+	if (!Props.IsValid()) return MakeError(TEXT("invalid property JSON"));
+
+	// "__slot": {..} targets the widget's slot instead of the widget.
+	const TSharedPtr<FJsonObject>* SlotProps;
+	if (Props->TryGetObjectField(TEXT("__slot"), SlotProps) && W->Slot)
+	{
+		ApplyProperties(W->Slot, *SlotProps);
+	}
+	ApplyProperties(W, Props);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::SetRootWidget(const FString& AssetPath, const FString& WidgetName)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	UWidget* W = WBP->WidgetTree->FindWidget(FName(*WidgetName));
+	if (!W) return MakeError(FString::Printf(TEXT("widget '%s' not found"), *WidgetName));
+
+	WBP->WidgetTree->RootWidget = W;
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+	SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::ListWidgetTypes(const FString& Filter)
+{
+	TArray<TSharedPtr<FJsonValue>> Types;
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		UClass* C = *It;
+		if (!C->IsChildOf(UWidget::StaticClass())) continue;
+		if (C->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists | CLASS_Hidden)) continue;
+		const FString CName = C->GetName();
+		if (!Filter.IsEmpty() && !CName.Contains(Filter)) continue;
+
+		TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("name"), CName);
+		Entry->SetStringField(TEXT("path"), C->GetPathName());
+		Types.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetArrayField(TEXT("types"), Types);
+	return SerializeJson(Result);
+}
+
+FString UWidgetBlueprintBuilder::CompileAndSaveWidget(const FString& AssetPath)
+{
+	UWidgetBlueprint* WBP = LoadWidgetBlueprint(AssetPath);
+	if (!WBP) return MakeError(FString::Printf(TEXT("WidgetBlueprint not found: %s"), *AssetPath));
+
+	FCompilerResultsLog Results;
+	Results.bSilentMode = true;
+	FKismetEditorUtilities::CompileBlueprint(WBP, EBlueprintCompileOptions::None, &Results);
+
+	TArray<TSharedPtr<FJsonValue>> Errors;
+	TArray<TSharedPtr<FJsonValue>> Warnings;
+	for (const TSharedRef<FTokenizedMessage>& Msg : Results.Messages)
+	{
+		const FString Text = Msg->ToText().ToString();
+		if (Msg->GetSeverity() == EMessageSeverity::Error)
+			Errors.Add(MakeShared<FJsonValueString>(Text));
+		else if (Msg->GetSeverity() == EMessageSeverity::Warning)
+			Warnings.Add(MakeShared<FJsonValueString>(Text));
+	}
+
+	const bool bOk = (Results.NumErrors == 0);
+	if (bOk) SaveAsset(WBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bOk);
+	Result->SetArrayField(TEXT("compile_errors"), Errors);
+	Result->SetArrayField(TEXT("compile_warnings"), Warnings);
+	return SerializeJson(Result);
+}

--- a/Source/Arbor/Public/ArborSettings.h
+++ b/Source/Arbor/Public/ArborSettings.h
@@ -96,6 +96,12 @@ public:
 			  ToolTip="Procedural Content Generation graph builders + landscape scattering."))
 	bool bEnablePCG = true;
 
+	UPROPERTY(EditAnywhere, Config, Category="Experimental Features",
+		meta=(DisplayName="Widget (UMG)",
+			  EditCondition="bEnableExperimentalFeatures",
+			  ToolTip="UMG Widget Blueprint authoring + preset-driven UI animations (ue5_widget / ue5_widget_animation)."))
+	bool bEnableWidget = true;
+
 	/** Returns a JSON blob describing which feature flags are enabled. Called by
 	 *  the ue5-bridge MCP server at boot via Remote Control API to decide which
 	 *  tool categories to register. */

--- a/Source/Arbor/Public/WidgetAnimationBuilder.h
+++ b/Source/Arbor/Public/WidgetAnimationBuilder.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "WidgetAnimationBuilder.generated.h"
+
+class UWidgetBlueprint;
+class UWidgetAnimation;
+class UMovieScene;
+class FJsonObject;
+
+/**
+ * Authoring of UMG widget animations (UWidgetAnimation) from designer-friendly
+ * preset recipes, driven by the ue5-bridge `ue5_widget_animation` tool.
+ *
+ * Primary API is presets (fade/slide/pop/pulse/strikeoff). A thin low-level
+ * AddAnimationTrack escape hatch exposes raw channel keyframes.
+ *
+ * Animations are stored on UWidgetBlueprint::Animations; after authoring the
+ * blueprint is recompiled so each animation surfaces as a UWidgetAnimation*
+ * variable referenceable from the event graph (PlayAnimation).
+ */
+UCLASS()
+class ARBOR_API UWidgetAnimationBuilder : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	/** Add (or extend) an animation from a preset spec.
+	 *  JSON: { name, tracks: [ { preset, target, duration?, direction?, distance?, overshoot? }, ... ] }
+	 *  Presets: fade_in, fade_out, slide_in, slide_out, pop, scale_in, pulse, strikeoff. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString AddAnimationFromPreset(const FString& AssetPath, const FString& PresetJsonString);
+
+	/** List animations on a WidgetBlueprint with durations and bindings. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString QueryAnimations(const FString& AssetPath);
+
+	/** Remove an animation by name. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString RemoveAnimation(const FString& AssetPath, const FString& AnimationName);
+
+	/** Low-level escape hatch: author a track with explicit channel keyframes.
+	 *  JSON: { animation, target, track_type:"float"|"transform2d", property?, duration?,
+	 *          channels:[ { component, keys:[ {t, v}, ... ] } ] }
+	 *  component for transform2d: TranslationX|TranslationY|ScaleX|ScaleY|Rotation */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString AddAnimationTrack(const FString& AssetPath, const FString& TrackJsonString);
+
+private:
+	static UWidgetAnimation* CreateOrGetAnimation(UWidgetBlueprint* WBP, FName AnimName);
+
+	/** Bind a widget by name; returns the possessable GUID (reuses an existing binding). */
+	static FGuid BindWidget(UWidgetAnimation* Anim, UWidgetBlueprint* WBP, const FString& WidgetName);
+
+	static void AddFloatTrack(UMovieScene* MS, const FGuid& Guid, const FString& PropertyName,
+		float StartVal, float EndVal, float Dur);
+
+	/** Key a single channel index (0..1) of a fresh 2D transform section. Channels:
+	 *  0=TranslationX 1=TranslationY 2=Rotation 3=ScaleX 4=ScaleY (see impl). */
+	static class UMovieScene2DTransformSection* AddTransformSection(UMovieScene* MS, const FGuid& Guid,
+		uint32 ChannelMask, float Dur);
+
+	static bool ApplyPreset(UWidgetBlueprint* WBP, UWidgetAnimation* Anim,
+		const TSharedPtr<FJsonObject>& Track, float& OutMaxDur, FString& OutError);
+
+	/** Create a thin strike-through Image overlay over a target text widget. */
+	static FString CreateStrikeOverlay(UWidgetBlueprint* WBP, const FString& TargetName, FString& OutError);
+
+	static void RecompileAndSave(UWidgetBlueprint* WBP);
+
+	static FString MakeError(const FString& Message);
+};

--- a/Source/Arbor/Public/WidgetBlueprintBuilder.h
+++ b/Source/Arbor/Public/WidgetBlueprintBuilder.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "WidgetBlueprintBuilder.generated.h"
+
+class UWidgetBlueprint;
+class UWidget;
+class UPanelWidget;
+class UWidgetTree;
+class FJsonObject;
+class FJsonValue;
+
+/**
+ * Authoring of UMG Widget Blueprints (the widget tree) from JSON, driven by the
+ * ue5-bridge MCP `ue5_widget` tool. Mirrors UBlueprintBuilder: JSON in, JSON
+ * string out, update-in-place (never delete-recreate, to preserve references).
+ *
+ * Event-graph editing is intentionally NOT here - a UWidgetBlueprint IS-A
+ * UBlueprint, so node/pin/connect editing goes through UBlueprintBuilder.
+ * Animations live in UWidgetAnimationBuilder.
+ */
+UCLASS()
+class ARBOR_API UWidgetBlueprintBuilder : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	/** Create a WidgetBlueprint subclass of a UUserWidget-derived class, optionally
+	 *  building the whole widget tree in one call.
+	 *  JSON: { name, parent_class, content_path?, tree?: [ widget_spec, ... ] }
+	 *  Each widget_spec: { name, type, parent?, root?, is_variable?, properties?, slot_properties? }
+	 *  @return JSON: { success, asset_path, bind_widgets:[...], error? } */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString BuildWidgetFromJSONString(const FString& JsonString, const FString& AssetPath);
+
+	/** Return the widget tree (names, classes, parent, slot, is_variable), the
+	 *  existing animation names, and the parent class's BindWidget/BindWidgetOptional
+	 *  properties so the caller knows which exact names to use. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString QueryWidget(const FString& AssetPath);
+
+	/** Add one widget under a named parent panel.
+	 *  WidgetJson: { name, type, parent?, root?, is_variable?, properties?, slot_properties? } */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString AddWidget(const FString& AssetPath, const FString& WidgetJsonString);
+
+	/** Remove a widget (and its children) from the tree by name. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString RemoveWidget(const FString& AssetPath, const FString& WidgetName);
+
+	/** Set properties on a widget. PropertyJson is an object of {PropertyName: value}.
+	 *  Handles Text, brush image (FSlateBrush.image = texture path), colors, fonts,
+	 *  Percent, Visibility, plus generic reflection. Use slot_properties via AddWidget
+	 *  for slot fields, or set property "__slot" : {..} here to target the slot. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString SetWidgetProperty(const FString& AssetPath, const FString& WidgetName, const FString& PropertyJsonString);
+
+	/** Set the tree root to an existing widget (usually a CanvasPanel/Overlay). */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString SetRootWidget(const FString& AssetPath, const FString& WidgetName);
+
+	/** Runtime discovery of available UWidget classes (mirror list_component_types). */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString ListWidgetTypes(const FString& Filter);
+
+	/** Compile + save the WidgetBlueprint. Surfaces "required widget binding is
+	 *  missing" and other compile errors verbatim. */
+	UFUNCTION(BlueprintCallable, Category = "Arbor")
+	static FString CompileAndSaveWidget(const FString& AssetPath);
+
+	// ---- Shared helpers (also used by UWidgetAnimationBuilder) ----
+
+	/** Load an existing WidgetBlueprint asset for editing, or nullptr. */
+	static UWidgetBlueprint* LoadWidgetBlueprint(const FString& AssetPath);
+
+	/** Resolve a UWidget subclass by short name ("TextBlock") or full path. */
+	static UClass* ResolveWidgetClass(const FString& TypeName);
+
+	/** Apply a JSON value to an FProperty, recursing into structs and arrays.
+	 *  Special-cases FSlateBrush ({image, draw_as, image_size, tint, margin}). */
+	static void ApplyJsonToProperty(FProperty* Prop, void* ValuePtr, const TSharedPtr<FJsonValue>& Json);
+
+private:
+	static UClass* ResolveParentWidgetClass(const FString& ClassName);
+
+	static UWidgetBlueprint* CreateWidgetBlueprintAsset(const FString& Name, const FString& AssetPath, UClass* ParentClass);
+
+	/** Construct a widget from a spec and parent it. Returns the new widget or nullptr. */
+	static UWidget* CreateWidgetFromSpec(UWidgetBlueprint* WBP, const TSharedPtr<FJsonObject>& Spec, FString& OutError);
+
+	static void ApplyProperties(UObject* Target, const TSharedPtr<FJsonObject>& Props);
+
+	/** Report the parent class's meta=(BindWidget)/BindWidgetOptional object properties. */
+	static TArray<TSharedPtr<FJsonValue>> CollectBindWidgetProperties(UClass* ParentClass);
+
+	static bool SaveAsset(UObject* Asset);
+
+	static FString MakeError(const FString& Message);
+};

--- a/bridge/CLAUDE.md
+++ b/bridge/CLAUDE.md
@@ -78,6 +78,8 @@ Result drives which categories `index.ts` registers.
 - **ue5_anchors** — Mesh anchor metadata + debug visualization
 - **ue5_concept_art_studio** — Unified concept art generation pipeline
 - **ue5_pcg** — PCG graph editing + execution; landscape scattering
+- **ue5_widget** — UMG Widget Blueprint authoring: create/query/edit the widget tree, set widget + slot properties (incl. brush images), set root, list widget types, compile
+- **ue5_widget_animation** — UMG widget animations via preset recipes (fade/slide/pop/pulse/strikeoff) + low-level keyframe track hatch
 
 ## Reporting bugs
 

--- a/bridge/src/features.ts
+++ b/bridge/src/features.ts
@@ -7,6 +7,7 @@ export interface Features {
   codex?: boolean;
   concept_art_studio?: boolean;
   pcg?: boolean;
+  widget?: boolean;
 }
 
 const ALL_EXPERIMENTAL_KEYS: ExperimentalFeatureKey[] = [
@@ -15,6 +16,7 @@ const ALL_EXPERIMENTAL_KEYS: ExperimentalFeatureKey[] = [
   "codex",
   "concept_art_studio",
   "pcg",
+  "widget",
 ];
 
 function parseEnvOverride(raw: string): Features {

--- a/bridge/src/registry/experimental.ts
+++ b/bridge/src/registry/experimental.ts
@@ -5,13 +5,16 @@ import { environmentTool } from "./environment.js";
 import { codexTool } from "./codex.js";
 import { conceptArtStudioTool } from "./concept-art-studio.js";
 import { pcgTool } from "./pcg.js";
+import { widgetTool } from "./widget.js";
+import { widgetAnimationTool } from "./widget-animation.js";
 
 export type ExperimentalFeatureKey =
   | "anchors"
   | "environment"
   | "codex"
   | "concept_art_studio"
-  | "pcg";
+  | "pcg"
+  | "widget";
 
 export interface ExperimentalToolEntry {
   name: string;
@@ -25,4 +28,6 @@ export const EXPERIMENTAL_TOOLS: ExperimentalToolEntry[] = [
   { name: "ue5_codex", tool: codexTool, featureKey: "codex" },
   { name: "ue5_concept_art_studio", tool: conceptArtStudioTool, featureKey: "concept_art_studio" },
   { name: "ue5_pcg", tool: pcgTool, featureKey: "pcg" },
+  { name: "ue5_widget", tool: widgetTool, featureKey: "widget" },
+  { name: "ue5_widget_animation", tool: widgetAnimationTool, featureKey: "widget" },
 ];

--- a/bridge/src/registry/index.ts
+++ b/bridge/src/registry/index.ts
@@ -14,3 +14,5 @@ export { anchorsTool } from "./anchors.js";
 export { environmentTool } from "./environment.js";
 export { codexTool } from "./codex.js";
 export { conceptArtStudioTool } from "./concept-art-studio.js";
+export { widgetTool } from "./widget.js";
+export { widgetAnimationTool } from "./widget-animation.js";

--- a/bridge/src/registry/widget-animation.ts
+++ b/bridge/src/registry/widget-animation.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { callArborJson } from "../ue5-client.js";
+import type { CategoryTool } from "./types.js";
+
+export const widgetAnimationTool: CategoryTool = {
+  description:
+    "UMG widget animations via designer-friendly preset recipes (fade_in, fade_out, slide_in, " +
+    "slide_out, pop, scale_in, pulse, strikeoff). One animation 'name' holds one or more tracks, " +
+    "so e.g. an 'Intro' = fade_in + slide_in. After authoring, the animation surfaces as a variable " +
+    "on the widget - play it from the event graph via ue5_blueprint (UUserWidget::PlayAnimation). " +
+    "A low-level add_track hatch exposes raw channel keyframes.",
+
+  actionParams: {
+    add_preset: {
+      summary: "Add/extend an animation from preset recipes",
+      required: ["asset_path", "preset_spec"],
+    },
+    query: {
+      summary: "List animations with durations and bindings",
+      required: ["asset_path"],
+    },
+    remove: {
+      summary: "Remove an animation by name",
+      required: ["asset_path", "animation_name"],
+    },
+    add_track: {
+      summary: "Low-level: author a track with explicit channel keyframes",
+      required: ["asset_path", "track_spec"],
+    },
+  },
+
+  readOnlyActions: ["query"],
+
+  schema: {
+    asset_path: z.string().optional().describe("Content path to the WidgetBlueprint asset"),
+    preset_spec: z.record(z.unknown()).optional().describe(
+      "Animation spec (add_preset): { name, tracks: [ { preset, target, duration?, " +
+      "direction?(left|right|top|bottom), distance?, overshoot? } ] }. " +
+      "Presets: fade_in, fade_out, slide_in, slide_out, pop, scale_in, pulse, strikeoff."
+    ),
+    animation_name: z.string().optional().describe("Animation name (remove)"),
+    track_spec: z.record(z.unknown()).optional().describe(
+      "Low-level track (add_track): { animation, target, track_type:'float'|'transform2d', " +
+      "property?, duration?, channels:[ { component, keys:[ {t, v} ] } ] }. " +
+      "transform2d components: TranslationX|TranslationY|ScaleX|ScaleY|Rotation"
+    ),
+  },
+
+  actions: {
+    async add_preset(p) {
+      if (!p.asset_path || !p.preset_spec) throw new Error("asset_path, preset_spec required");
+      return callArborJson("WidgetAnimationBuilder", "AddAnimationFromPreset", {
+        AssetPath: p.asset_path,
+        PresetJsonString: JSON.stringify(p.preset_spec),
+      });
+    },
+
+    async query(p) {
+      if (!p.asset_path) throw new Error("asset_path required");
+      return callArborJson("WidgetAnimationBuilder", "QueryAnimations", { AssetPath: p.asset_path });
+    },
+
+    async remove(p) {
+      if (!p.asset_path || !p.animation_name) throw new Error("asset_path, animation_name required");
+      return callArborJson("WidgetAnimationBuilder", "RemoveAnimation", {
+        AssetPath: p.asset_path,
+        AnimationName: p.animation_name,
+      });
+    },
+
+    async add_track(p) {
+      if (!p.asset_path || !p.track_spec) throw new Error("asset_path, track_spec required");
+      return callArborJson("WidgetAnimationBuilder", "AddAnimationTrack", {
+        AssetPath: p.asset_path,
+        TrackJsonString: JSON.stringify(p.track_spec),
+      });
+    },
+  },
+};

--- a/bridge/src/registry/widget.ts
+++ b/bridge/src/registry/widget.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+import { callArborJson } from "../ue5-client.js";
+import type { CategoryTool } from "./types.js";
+
+export const widgetTool: CategoryTool = {
+  description:
+    "UMG Widget Blueprint authoring (the widget tree): create a WidgetBlueprint subclass of a " +
+    "UUserWidget/UCommonActivatableWidget, build/query/edit the widget hierarchy, set widget and " +
+    "slot properties (including brush images from textures), set the root, discover widget types, " +
+    "and compile. Event-graph wiring (e.g. PlayAnimation on an event) goes through ue5_blueprint; " +
+    "animations go through ue5_widget_animation.",
+
+  actionParams: {
+    create: {
+      summary: "Create a WidgetBlueprint, optionally building the whole tree",
+      required: ["name"],
+      optional: ["parent_class", "content_path", "tree"],
+    },
+    query: {
+      summary: "Query widget tree, animations, and parent-class BindWidget properties",
+      required: ["asset_path"],
+    },
+    add_widget: {
+      summary: "Add one widget under a named parent panel",
+      required: ["asset_path", "widget_spec"],
+    },
+    remove_widget: {
+      summary: "Remove a widget (and its children) by name",
+      required: ["asset_path", "widget_name"],
+    },
+    set_widget_property: {
+      summary: "Set widget properties (Text, brush image, color, Percent, Visibility, slot via __slot)",
+      required: ["asset_path", "widget_name", "property_spec"],
+    },
+    set_root: {
+      summary: "Set the tree root to an existing widget",
+      required: ["asset_path", "widget_name"],
+    },
+    list_widget_types: {
+      summary: "List available UWidget classes (never guess)",
+      optional: ["filter"],
+    },
+    compile: {
+      summary: "Compile + save; surfaces BindWidget/compile errors verbatim",
+      required: ["asset_path"],
+    },
+  },
+
+  readOnlyActions: ["query", "list_widget_types"],
+
+  schema: {
+    asset_path: z.string().optional().describe("Content path to the WidgetBlueprint asset"),
+    name: z.string().optional().describe("Widget Blueprint name (create)"),
+    parent_class: z.string().optional().describe(
+      "Parent UUserWidget subclass by short name or /Script path (create). Default UserWidget."
+    ),
+    content_path: z.string().optional().describe("Content folder (create). Default /Game/UI/Widgets"),
+    tree: z.array(z.record(z.unknown())).optional().describe(
+      "Widget specs in order (parents before children). Each: " +
+      "{name, type, parent?, root?, is_variable?, properties?, slot_properties?}"
+    ),
+    widget_spec: z.record(z.unknown()).optional().describe(
+      "Single widget spec (add_widget): {name, type, parent?, root?, is_variable?, properties?, slot_properties?}"
+    ),
+    widget_name: z.string().optional().describe("Target widget name (remove_widget, set_widget_property, set_root)"),
+    property_spec: z.record(z.unknown()).optional().describe(
+      "Object of {PropertyName: value} (set_widget_property). Brush image: " +
+      '{"Brush":{"image":"/Game/UI/T_Panel","draw_as":"Box","image_size":{"x":256,"y":64}}}. ' +
+      'Slot fields: {"__slot":{...}}'
+    ),
+    filter: z.string().optional().describe("Substring filter for class names (list_widget_types)"),
+  },
+
+  actions: {
+    async create(p) {
+      if (!p.name) throw new Error("name required");
+      const contentPath = (p.content_path as string) || "/Game/UI/Widgets";
+      const spec: Record<string, unknown> = {
+        name: p.name,
+        parent_class: (p.parent_class as string) || "UserWidget",
+        content_path: contentPath,
+      };
+      if (p.tree) spec.tree = p.tree;
+      return callArborJson("WidgetBlueprintBuilder", "BuildWidgetFromJSONString", {
+        JsonString: JSON.stringify(spec),
+        AssetPath: contentPath,
+      });
+    },
+
+    async query(p) {
+      if (!p.asset_path) throw new Error("asset_path required");
+      return callArborJson("WidgetBlueprintBuilder", "QueryWidget", { AssetPath: p.asset_path });
+    },
+
+    async add_widget(p) {
+      if (!p.asset_path || !p.widget_spec) throw new Error("asset_path, widget_spec required");
+      return callArborJson("WidgetBlueprintBuilder", "AddWidget", {
+        AssetPath: p.asset_path,
+        WidgetJsonString: JSON.stringify(p.widget_spec),
+      });
+    },
+
+    async remove_widget(p) {
+      if (!p.asset_path || !p.widget_name) throw new Error("asset_path, widget_name required");
+      return callArborJson("WidgetBlueprintBuilder", "RemoveWidget", {
+        AssetPath: p.asset_path,
+        WidgetName: p.widget_name,
+      });
+    },
+
+    async set_widget_property(p) {
+      if (!p.asset_path || !p.widget_name || !p.property_spec)
+        throw new Error("asset_path, widget_name, property_spec required");
+      return callArborJson("WidgetBlueprintBuilder", "SetWidgetProperty", {
+        AssetPath: p.asset_path,
+        WidgetName: p.widget_name,
+        PropertyJsonString: JSON.stringify(p.property_spec),
+      });
+    },
+
+    async set_root(p) {
+      if (!p.asset_path || !p.widget_name) throw new Error("asset_path, widget_name required");
+      return callArborJson("WidgetBlueprintBuilder", "SetRootWidget", {
+        AssetPath: p.asset_path,
+        WidgetName: p.widget_name,
+      });
+    },
+
+    async list_widget_types(p) {
+      return callArborJson("WidgetBlueprintBuilder", "ListWidgetTypes", {
+        Filter: (p.filter as string) ?? "",
+      });
+    },
+
+    async compile(p) {
+      if (!p.asset_path) throw new Error("asset_path required");
+      return callArborJson("WidgetBlueprintBuilder", "CompileAndSaveWidget", { AssetPath: p.asset_path });
+    },
+  },
+};


### PR DESCRIPTION
Adds experimental `ue5_widget` and `ue5_widget_animation` MCP tools for authoring UMG Widget Blueprints and designer-friendly UI animations, plus a few blueprint-tooling fixes uncovered while building them.

## New tools (experimental, gated by a `widget` feature flag)

**`ue5_widget`** (`UWidgetBlueprintBuilder`) - create a WidgetBlueprint subclass of any `UUserWidget`/`UCommonActivatableWidget`, build/query/edit the widget tree, set widget + slot properties (including brush images from textures), set the root, list widget types, compile. `query` reports the parent class's `BindWidget`/`BindWidgetOptional` properties so callers use exact names; `add_widget` takes an optional `index` to control panel/overlay child ordering.

**`ue5_widget_animation`** (`UWidgetAnimationBuilder`) - designer-friendly preset recipes (`fade_in/out`, `slide_in/out`, `pop`/`scale_in`, `pulse`, `strikeoff`) that author real `UWidgetAnimation` + `UMovieScene` tracks/sections/keyframes, plus a low-level `add_track` keyframe hatch.

Event-graph editing (PlayAnimation, SetText, ...) reuses the existing `ue5_blueprint` tool since a WidgetBlueprint is a UBlueprint.

## Blueprint-tooling fixes (`BlueprintBuilder`)
- **`get_node_pins` no longer crashes the editor** on UMG/member-function introspection - the temp graph is parented to the Blueprint so nodes resolve `GetBlueprint()` during pin allocation.
- **`FormatText`** node type: sets the format string and regenerates one argument pin per `{placeholder}`.
- **`CreateWidget`** and other editor-module K2 nodes now resolve via `UClass::TryFindTypeSlow` (reflected `K2Node_` name), with ExposeOnSpawn pins regenerated once the Class pin is set.

## Build / registration
- `Arbor.Build.cs`: +UMG, UMGEditor, MovieScene, MovieSceneTracks.
- `ArborSettings`: new `bEnableWidget` flag + `GetEnabledFeaturesJson` entry.
- Docs: CLAUDE.md "Widget Editing (UMG)" + "Widget Animations"; bridge stable/experimental tool list.

## Verification (UE 5.7, in-editor)
Built three HUD archetypes (quest tracker, notification toast, quest-giver dialogue), drove the preset animations and confirmed the keyframed RenderOpacity/RenderTransform deltas, assigned brush textures, and used the tracker live in a quest flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
