### PR TITLE
Material graph auto-layout (verb + auto-on-build, with function-graph fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,7 +434,7 @@ Granular material editing lives in `UArborMaterialGraphTools` (MCP `ue5_material
 
 ### Graph layout
 
-`layout(path)` / `arbor.materials.layout_material(path)` auto-arranges a material's or material function's nodes into a readable left-to-right column layout (UE's built-in `LayoutMaterialExpressions` / `LayoutMaterialFunctionExpressions`; auto-detects the asset type, no editor window needed, no recompile - it only moves nodes). `build_material` / `build_material_function` run this automatically at the end so Arbor-built graphs open tidy instead of as a pile of overlapping nodes at the origin. On by default; it overrides any manual `x`/`y` in the spec, so pass `"auto_layout": false` to keep hand-placed positions.
+`layout(path)` / `arbor.materials.layout_material(path)` auto-arranges a material's or material function's nodes into a readable left-to-right column layout. Auto-detects the asset type, no editor window needed, no recompile (it only moves nodes). Materials use UE's built-in `LayoutMaterialExpressions`; functions use Arbor's own layered layout (`LayoutFunctionGraph`), because UE's `LayoutMaterialFunctionExpressions` only positions input nodes for functions that have inputs and leaves the rest piled at the origin. `build_material` / `build_material_function` run this automatically at the end so Arbor-built graphs open tidy instead of as a pile of overlapping nodes at the origin. On by default; it overrides any manual `x`/`y` in the spec, so pass `"auto_layout": false` to keep hand-placed positions.
 
 ### Material Functions (authoring)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,10 @@ Then ask the user to look at UE5 and choose. Clean up: `preview.remove_preview_s
 
 Granular material editing lives in `UArborMaterialGraphTools` (MCP `ue5_materials`, or `arbor.materials`). It edits a material's expression graph by stable sentinel IDs stored in each expression's `Desc` field (`__arbor_id:<id>`), surviving save/reload. `build_material(spec)` builds/updates a whole material idempotently in one `FMaterialUpdateContext`.
 
+### Graph layout
+
+`layout(path)` / `arbor.materials.layout_material(path)` auto-arranges a material's or material function's nodes into a readable left-to-right column layout (UE's built-in `LayoutMaterialExpressions` / `LayoutMaterialFunctionExpressions`; auto-detects the asset type, no editor window needed, no recompile - it only moves nodes). `build_material` / `build_material_function` run this automatically at the end so Arbor-built graphs open tidy instead of as a pile of overlapping nodes at the origin. On by default; it overrides any manual `x`/`y` in the spec, so pass `"auto_layout": false` to keep hand-placed positions.
+
 ### Material Functions (authoring)
 
 `build_material_function(spec)` / `query_material_function(path)` author a `UMaterialFunction` with the same spec shape as `build_material`, with these differences:

--- a/Content/Python/arbor/materials.py
+++ b/Content/Python/arbor/materials.py
@@ -302,6 +302,17 @@ def build_material(spec):
     return _call_cpp(unreal.ArborMaterialGraphTools.build_material(json.dumps(spec)))
 
 
+def layout_material(path):
+    """Auto-arrange a material or material function's nodes into a readable layout.
+
+    Detects whether `path` is a Material or a MaterialFunction and runs UE's
+    built-in LayoutMaterialExpressions / LayoutMaterialFunctionExpressions, then
+    saves. build_material / build_material_function already do this at the end
+    unless the spec sets "auto_layout": False (which preserves manual x/y).
+    """
+    return _call_cpp(unreal.ArborMaterialGraphTools.layout_material(json.dumps({"path": path})))
+
+
 def build_material_checked(spec):
     """Build a material AND verify it actually compiled, in one call.
 

--- a/Source/Arbor/Private/ArborMaterialGraphTools.cpp
+++ b/Source/Arbor/Private/ArborMaterialGraphTools.cpp
@@ -1191,6 +1191,16 @@ FString UArborMaterialGraphTools::BuildMaterial(const FString& JsonSpec)
 		// UpdateCtx destructor here triggers the recompile.
 	}
 
+	// Auto-arrange nodes (default on) so Arbor-built graphs aren't a pile of
+	// overlapping nodes. Layout only moves nodes - no recompile. Overrides any
+	// manual x/y; pass "auto_layout": false to keep hand-placed positions.
+	bool bAutoLayout = true;
+	Spec->TryGetBoolField(TEXT("auto_layout"), bAutoLayout);
+	if (bAutoLayout)
+	{
+		UMaterialEditingLibrary::LayoutMaterialExpressions(Mat);
+	}
+
 	UEditorAssetLibrary::SaveLoadedAsset(Mat);
 
 	const TSharedRef<FJsonObject> Out = MakeShared<FJsonObject>();
@@ -1631,6 +1641,16 @@ FString UArborMaterialGraphTools::BuildMaterialFunction(const FString& JsonSpec)
 	// 5. Finalise: rebuild input/output metadata and propagate to any materials
 	//    referencing this function. Functions do not self-recompile.
 	UMaterialEditingLibrary::UpdateMaterialFunction(Func, nullptr);
+
+	// Auto-arrange nodes (default on). Overrides manual x/y; pass
+	// "auto_layout": false to keep hand-placed positions.
+	bool bAutoLayout = true;
+	Spec->TryGetBoolField(TEXT("auto_layout"), bAutoLayout);
+	if (bAutoLayout)
+	{
+		UMaterialEditingLibrary::LayoutMaterialFunctionExpressions(Func);
+	}
+
 	UEditorAssetLibrary::SaveLoadedAsset(Func);
 
 	TArray<TSharedPtr<FJsonValue>> InputsArr, OutputsArr;
@@ -1643,5 +1663,48 @@ FString UArborMaterialGraphTools::BuildMaterialFunction(const FString& JsonSpec)
 	Out->SetArrayField(TEXT("inputs"), InputsArr);
 	Out->SetArrayField(TEXT("outputs"), OutputsArr);
 	if (Unresolved.Num() > 0) Out->SetArrayField(TEXT("unresolved_connections"), Unresolved);
+	return JsonOk(Out);
+}
+
+// ============================================================================
+// LayoutMaterial - auto-arrange a material / material function's nodes
+// ============================================================================
+
+FString UArborMaterialGraphTools::LayoutMaterial(const FString& JsonParams)
+{
+	TSharedPtr<FJsonObject> Params = ParseJson(JsonParams);
+	if (!Params.IsValid()) return JsonError(TEXT("Invalid JSON"));
+
+	FString Path;
+	if (!Params->TryGetStringField(TEXT("path"), Path))
+		Params->TryGetStringField(TEXT("material_path"), Path);
+	if (Path.IsEmpty()) return JsonError(TEXT("path is required"));
+
+	UObject* Asset = UEditorAssetLibrary::LoadAsset(Path);
+	if (!Asset) return JsonError(FString::Printf(TEXT("Asset not found: %s"), *Path));
+
+	const TSharedRef<FJsonObject> Out = MakeShared<FJsonObject>();
+	Out->SetStringField(TEXT("path"), Path);
+
+	if (UMaterial* Mat = Cast<UMaterial>(Asset))
+	{
+		UMaterialEditingLibrary::LayoutMaterialExpressions(Mat);
+		Mat->MarkPackageDirty();
+		Out->SetStringField(TEXT("type"), TEXT("material"));
+		Out->SetNumberField(TEXT("expression_count"), GetExpressions(Mat).Num());
+	}
+	else if (UMaterialFunction* Func = Cast<UMaterialFunction>(Asset))
+	{
+		UMaterialEditingLibrary::LayoutMaterialFunctionExpressions(Func);
+		Func->MarkPackageDirty();
+		Out->SetStringField(TEXT("type"), TEXT("material_function"));
+		Out->SetNumberField(TEXT("expression_count"), GetFunctionExpressions(Func).Num());
+	}
+	else
+	{
+		return JsonError(FString::Printf(TEXT("Asset is not a Material or MaterialFunction: %s"), *Path));
+	}
+
+	UEditorAssetLibrary::SaveLoadedAsset(Asset);
 	return JsonOk(Out);
 }

--- a/Source/Arbor/Private/ArborMaterialGraphTools.cpp
+++ b/Source/Arbor/Private/ArborMaterialGraphTools.cpp
@@ -1313,6 +1313,66 @@ namespace
 		return Cast<UMaterialFunction>(Asset);
 	}
 
+	// UE's UMaterialEditingLibrary::LayoutMaterialFunctionExpressions only positions
+	// FunctionInput nodes when the function has inputs (it walks backward FROM the
+	// inputs, which dead-ends, leaving every other node piled at the origin). Do a
+	// proper layered layout: column = longest backward distance from the FunctionOutput
+	// nodes (output column 0 at the right, inputs furthest left), stacked within columns.
+	void LayoutFunctionGraph(UMaterialFunction* Func)
+	{
+		if (!Func) return;
+		const TArray<TObjectPtr<UMaterialExpression>>& Exprs = GetFunctionExpressions(Func);
+
+		// Roots = FunctionOutput nodes (fallback: everything, if the function has none).
+		TArray<UMaterialExpression*> Roots;
+		for (const TObjectPtr<UMaterialExpression>& E : Exprs)
+		{
+			if (E && E->IsA<UMaterialExpressionFunctionOutput>()) Roots.Add(E);
+		}
+		if (Roots.Num() == 0)
+		{
+			for (const TObjectPtr<UMaterialExpression>& E : Exprs) { if (E) Roots.Add(E); }
+		}
+
+		// Longest-path column, walking backward through each node's inputs.
+		TMap<UMaterialExpression*, int32> Column;
+		TArray<TPair<UMaterialExpression*, int32>> Stack;
+		for (UMaterialExpression* R : Roots) Stack.Add(TPair<UMaterialExpression*, int32>(R, 0));
+		while (Stack.Num() > 0)
+		{
+			const TPair<UMaterialExpression*, int32> Cur = Stack.Pop();
+			UMaterialExpression* E = Cur.Key;
+			if (!E) continue;
+			const int32 Col = Cur.Value;
+			if (int32* Existing = Column.Find(E)) { if (*Existing >= Col) continue; }
+			Column.Add(E, Col);
+			const int32 NumInputs = E->CountInputs();
+			for (int32 i = 0; i < NumInputs; ++i)
+			{
+				FExpressionInput* In = E->GetInput(i);
+				if (In && In->Expression) Stack.Add(TPair<UMaterialExpression*, int32>(In->Expression, Col + 1));
+			}
+		}
+		for (const TObjectPtr<UMaterialExpression>& E : Exprs)  // disconnected -> column 0
+		{
+			if (E && !Column.Contains(E)) Column.Add(E, 0);
+		}
+
+		// Place: X by column (output right, inputs left); stack vertically per column.
+		static const int32 ColWidth = 300;
+		static const int32 RowPadding = 40;
+		TMap<int32, int32> ColumnY;
+		for (const TObjectPtr<UMaterialExpression>& E : Exprs)
+		{
+			if (!E) continue;
+			const int32 Col = Column[E];
+			int32& Y = ColumnY.FindOrAdd(Col);
+			E->MaterialExpressionEditorX = -ColWidth * Col;
+			E->MaterialExpressionEditorY = Y;
+			Y += E->GetHeight() + RowPadding;
+		}
+	}
+
 	UMaterialFunction* LoadOrCreateMaterialFunction(const FString& Path, bool& bOutCreated)
 	{
 		bOutCreated = false;
@@ -1648,7 +1708,7 @@ FString UArborMaterialGraphTools::BuildMaterialFunction(const FString& JsonSpec)
 	Spec->TryGetBoolField(TEXT("auto_layout"), bAutoLayout);
 	if (bAutoLayout)
 	{
-		UMaterialEditingLibrary::LayoutMaterialFunctionExpressions(Func);
+		LayoutFunctionGraph(Func);
 	}
 
 	UEditorAssetLibrary::SaveLoadedAsset(Func);
@@ -1695,7 +1755,7 @@ FString UArborMaterialGraphTools::LayoutMaterial(const FString& JsonParams)
 	}
 	else if (UMaterialFunction* Func = Cast<UMaterialFunction>(Asset))
 	{
-		UMaterialEditingLibrary::LayoutMaterialFunctionExpressions(Func);
+		LayoutFunctionGraph(Func);
 		Func->MarkPackageDirty();
 		Out->SetStringField(TEXT("type"), TEXT("material_function"));
 		Out->SetNumberField(TEXT("expression_count"), GetFunctionExpressions(Func).Num());

--- a/Source/Arbor/Public/ArborMaterialGraphTools.h
+++ b/Source/Arbor/Public/ArborMaterialGraphTools.h
@@ -220,4 +220,20 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Arbor|MaterialGraph")
 	static FString BuildMaterialFunction(const FString& JsonSpec);
+
+	// ---- Graph layout ----
+
+	/**
+	 * Auto-arrange a material's or material function's expression nodes into a
+	 * readable left-to-right column layout, using UE's built-in
+	 * LayoutMaterialExpressions / LayoutMaterialFunctionExpressions. Detects which
+	 * asset type the path is. Layout only moves nodes (editor metadata), so no
+	 * recompile happens. build_material / build_material_function also run this
+	 * automatically at the end unless the spec sets "auto_layout": false.
+	 *
+	 * @param JsonParams  {"path": "/Game/.../M_Foo"}  ("material_path" also accepted)
+	 * @return JSON: {success, path, type, expression_count}
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Arbor|MaterialGraph")
+	static FString LayoutMaterial(const FString& JsonParams);
 };

--- a/bridge/src/registry/materials.ts
+++ b/bridge/src/registry/materials.ts
@@ -93,6 +93,10 @@ export const materialsTool: CategoryTool = {
       summary: "Build or update a complete Material Function from a JSON spec (idempotent). No outputs/flags block; inputs/outputs are FunctionInput/FunctionOutput nodes. See BuildMaterialFunction docs for schema.",
       required: ["spec"],
     },
+    layout: {
+      summary: "Auto-arrange a material or material function's nodes into a readable left-to-right layout (UE built-in). build/build_function already do this unless the spec sets auto_layout:false.",
+      required: ["path"],
+    },
   },
 
   schema: {
@@ -140,6 +144,7 @@ export const materialsTool: CategoryTool = {
     property: z.string().optional().describe("Material output property: BaseColor/Normal/Roughness/Metallic/EmissiveColor/Opacity/AmbientOcclusion/WorldPositionOffset"),
     spec: z.record(z.any()).optional().describe("Full BuildMaterial / BuildMaterialFunction spec — see ArborMaterialGraphTools.h for schema"),
     function_path: z.string().optional().describe("Material Function asset path for query_function (e.g. /Game/Materials/Functions/MF_SDF_Circle)"),
+    path: z.string().optional().describe("Material or Material Function asset path for layout (auto-detects type)"),
   },
 
   actions: {
@@ -327,6 +332,16 @@ export const materialsTool: CategoryTool = {
       if (!p.spec) throw new Error("spec required");
       return callArborJson("ArborMaterialGraphTools", "BuildMaterialFunction", {
         JsonSpec: JSON.stringify(p.spec),
+      });
+    },
+
+    // ---- Graph layout ----
+
+    async layout(p) {
+      const path = (p.path ?? p.material_path ?? p.function_path) as string | undefined;
+      if (!path) throw new Error("path required");
+      return callArborJson("ArborMaterialGraphTools", "LayoutMaterial", {
+        JsonParams: JSON.stringify({ path }),
       });
     },
   },


### PR DESCRIPTION
## Summary

Arbor-built materials/MFs came out with every node stacked at the origin (unreadable). This adds graph auto-layout so they open tidy.

- **`layout` verb** (`arbor.materials.layout_material(path)` / `ue5_materials` action `layout`): auto-detects material vs material function and arranges nodes into a readable left-to-right column layout. No editor window needed, no recompile (it only moves nodes).
- **Auto-on-build**: `build_material` / `build_material_function` now lay out at the end by default (`auto_layout` flag, default on; set `auto_layout: false` to keep manual `x`/`y`), so new graphs are never overlapping.
- **Function-graph fix**: UE's `LayoutMaterialFunctionExpressions` only positions `FunctionInput` nodes when a function has inputs (it walks backward *from the inputs*, which dead-ends), leaving the output + all math piled at the origin. Added `LayoutFunctionGraph` - a layered layout that columns nodes by longest backward distance from the `FunctionOutput` nodes. Materials keep UE's built-in `LayoutMaterialExpressions` (which works).

## Validation
- `layout_material` on a 20-node material: nodes go from all-at-origin to 20 distinct positions; type reported as `material`.
- `layout_material` on the procedural MFs: clean left-to-right flow (inputs left, output right), every internal node at a distinct position (verified `MF_SDF_Box`, `MF_UV_Swirl`, etc.).
- Auto-on-build: a fresh material's nodes come out spread automatically; `auto_layout: false` leaves them at the origin.
- Bridge TS compiles; editor rebuilt/relaunched clean.

Follow-up to #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
