### PR TITLE
Custom HLSL nodes + shader translation (material-authoring Phases 5-6)

### DIFF
--- a/.claude/skills/material-authoring/SKILL.md
+++ b/.claude/skills/material-authoring/SKILL.md
@@ -6,8 +6,9 @@ description: Use this skill whenever the user asks for help creating, designing,
   or visual styles. Use this even when the user doesn't say "material"
   explicitly but is clearly describing a surface look ("how would I do wet
   asphalt", "I want a cel-shaded look"). MVP scope: natural-language
-  descriptions only, legacy PBR materials. Image input and shader-code input
-  fall through to a not-yet-implemented response.
+  descriptions only, legacy PBR materials. Image input falls through to a
+  not-yet-implemented response; shader code (GLSL / HLSL / ShaderToy) is
+  translated into a Custom-node material (see "Shader translation").
 ---
 
 # Material authoring workflow
@@ -20,7 +21,7 @@ Arbor conventions you already know are in `Plugins/Arbor/CLAUDE.md` (read once a
 
 - **Natural language description** -> proceed to Step 2
 - **Reference image** -> reply: "image input isn't supported yet in v1; please describe what you want and I'll match against the catalog"
-- **Shader code / ShaderToy URL** -> reply: "shader translation isn't supported yet in v1; let me know what visual effect you want and I'll find the closest catalog entry"
+- **Shader code / ShaderToy URL** -> go to the **Shader translation** section near the end of this skill
 
 ## Step 2: map the description to tags + traits
 
@@ -135,6 +136,23 @@ extract_function.extract("/Game/Assets/Materials/Functions/Procedural/MF_<Name>"
 
 A function has no material-output pins or flags: its inputs are `MaterialExpressionFunctionInput` nodes and its outputs are `MaterialExpressionFunctionOutput` nodes. Use `mat.query_material_function(path)` to inspect an existing one, and `mat.list_expression_types("...")` / `mat.get_expression_class_params("...")` to discover node classes and pin names rather than guessing.
 
+## Shader translation
+
+Turn pasted shader code (GLSL, HLSL, or a ShaderToy URL/snippet) into a working material by wrapping the math in a `MaterialExpressionCustom` node. Read [references/custom_node_context.md](references/custom_node_context.md) (HLSL scope, texture sampling) and [references/glsl_hlsl_mapping.md](references/glsl_hlsl_mapping.md) (syntax table) before writing the `Code`.
+
+1. **Identify the source + entry point.** ShaderToy: `void mainImage(out vec4 fragColor, in vec2 fragCoord)`. Plain GLSL: `void main()`. Pasted `.usf`/HLSL: already close - skip the syntax pass.
+2. **Map inputs to graph nodes** (each becomes a `custom_input`), per [references/shadertoy_inputs.md](references/shadertoy_inputs.md):
+   - normalized UV (`fragCoord/iResolution`) -> a `MaterialExpressionTextureCoordinate` wired to a `UV` input
+   - `iTime` -> a `MaterialExpressionTime` wired to a `Time` input
+   - `iChannel0..3` samplers -> a `MaterialExpressionTextureObjectParameter` per channel wired to a `Tex` input; sample with `Texture2DSample(Tex, TexSampler, uv)`
+   - named uniforms you want artist-tweakable -> `ScalarParameter` / `VectorParameter` inputs; magic numbers stay inline
+3. **GLSL -> HLSL pass** (mechanical, see the table): `vec*`->`float*`, `mix`->`lerp`, `fract`->`frac`, `mod`->`fmod` (mind negatives), `texture(s,uv)`->`Texture2DSample(s,sSampler,uv)`, `gl_FragCoord`->`Parameters.SvPosition`.
+4. **Pick the output.** ShaderToy is unlit -> build an **Unlit** material, route the Custom node to `EmissiveColor`. (Surface shaders that compute normal/roughness can split outputs on a Lit material; default to Unlit.)
+5. **Build it.** One `MaterialExpressionCustom` (`Code` = the translated body returning the right `OutputType`; `custom_inputs` = the named inputs) + the input nodes, wired via `connections`, output -> `EmissiveColor`. Call `arbor.materials.build_material(spec)`.
+6. **Validate.** `query_material(path).compile_errors` must be empty (lit-grey = the HLSL didn't compile - read the error). Render a thumbnail and compare to the source. Time-driven shaders only animate in PIE/Realtime, not in a still.
+
+Keep the Custom node recognisably the original shader; the graph around it is just inputs and the output. Worked example: [shader_translation/examples/plasma.md](shader_translation/examples/plasma.md).
+
 ## Reference files
 
 - [<project>/MaterialCatalog/vocabulary.md](<project>/MaterialCatalog/vocabulary.md) - tag and trait vocabulary
@@ -142,6 +160,9 @@ A function has no material-output pins or flags: its inputs are `MaterialExpress
 - [<project>/MaterialCatalog/README.md](<project>/MaterialCatalog/README.md) - entry shape + how to add new ones
 - [references/pbr_quick.md](references/pbr_quick.md) - PBR defaults cheat sheet
 - [references/shading_models.md](references/shading_models.md) - shading model selection
+- [references/custom_node_context.md](references/custom_node_context.md) - Custom HLSL node scope, texture sampling, limits
+- [references/glsl_hlsl_mapping.md](references/glsl_hlsl_mapping.md) - GLSL -> HLSL syntax table
+- [references/shadertoy_inputs.md](references/shadertoy_inputs.md) - ShaderToy uniform -> UE node mapping
 - [extraction/](extraction/) - extract_material / extract_function / extract_batch / validate_roundtrip scripts for growing the catalog
 
 ## Common mistakes

--- a/.claude/skills/material-authoring/references/custom_node_context.md
+++ b/.claude/skills/material-authoring/references/custom_node_context.md
@@ -1,0 +1,83 @@
+# UE5 Custom Node (MaterialExpressionCustom) - compilation context
+
+The Custom node is UE's escape hatch from the visual graph: raw HLSL embedded into the
+generated material shader. Use it for math that is annoying or impossible to express as
+discrete nodes (noise, SDFs, raymarches, custom BRDFs).
+
+## Authoring via Arbor
+
+In a `build_material` / `build_material_function` spec, a Custom node is one expression:
+
+```json
+{
+  "id": "noise",
+  "class": "MaterialExpressionCustom",
+  "properties": {
+    "Description": "FBM noise",
+    "Code": "return fbm(UV * Scale);",
+    "OutputType": "CMOT_Float1"
+  },
+  "custom_inputs": [ { "name": "UV" }, { "name": "Scale" } ]
+}
+```
+
+- `Code`, `OutputType`, `Description` are normal `properties` (set via reflection).
+- **`custom_inputs` is a TOP-LEVEL key on the expression**, not under `properties`. Each
+  `{ "name": "X" }` becomes an input pin named `X` and an HLSL variable `X` in the body.
+  Wire into it with the normal `connections` array (`to_input: "X"`).
+- `OutputType`: `CMOT_Float1` / `CMOT_Float2` / `CMOT_Float3` / `CMOT_Float4`, or
+  `CMOT_MaterialAttributes` for the multi-output case (advanced).
+- The `Code` string is a function *body* - it must `return` a value of the `OutputType`.
+
+## Variable scope inside the Code body
+
+Your code runs inside a generated function with these implicitly available:
+
+- `Parameters` - `FMaterialPixelParameters`:
+  - `Parameters.WorldPosition` - float3 world-space position
+  - `Parameters.SvPosition` - float4 screen-space position
+  - `Parameters.TangentToWorld[2]` - float3 world-space surface normal
+  - `Parameters.TexCoords[N]` - float2 UVs at index N
+  - `Parameters.VertexColor` - float4 vertex colour
+  - `Parameters.CameraVector` - float3 from surface to camera
+- `View` - global view state (`View.GameTime`, `View.WorldCameraOrigin`, ...)
+
+Prefer wiring data in as a named `custom_input` (a `TexCoordinate`, `Time`, parameter, etc.)
+over reaching into `Parameters` - it keeps the node reusable and the inputs swappable.
+
+## Texture sampling (common failure)
+
+```hlsl
+// WRONG (GLSL / D3D9):  tex2D(MyTex, uv)   texture(MyTex, uv)
+// RIGHT (UE5 Custom):
+Texture2DSample(MyTex, MyTexSampler, uv)
+```
+
+Every Texture custom_input automatically gets a `<Name>Sampler` companion.
+
+## GLSL -> HLSL quick map (see shader_translation/references for the full table)
+
+| GLSL | HLSL |
+|---|---|
+| `vec2/3/4` | `float2/3/4` |
+| `mat3/4` | `float3x3/4x4` |
+| `mix(a,b,t)` | `lerp(a,b,t)` |
+| `fract(x)` | `frac(x)` |
+| `mod(a,b)` | `fmod(a,b)` (differs on negatives; use `a - b*floor(a/b)` to match GLSL) |
+| `dFdx/dFdy` | `ddx/ddy` |
+| `inversesqrt(x)` | `rsqrt(x)` |
+| `texture(s,uv)` | `Texture2DSample(s, sSampler, uv)` |
+
+## Limitations
+
+- One output by default. Multiple outputs need `OutputType: CMOT_MaterialAttributes` +
+  the `AdditionalOutputs` array (advanced).
+- Loops are unrolled at compile time - heavy loops compile slowly and run badly.
+- No recursion; non-uniform dynamic branching compiles but performs poorly.
+
+## Validating a Custom node
+
+A material that renders as the default lit-grey sphere FAILED to compile. Read
+`query_material(path).compile_errors` for the HLSL error (e.g. an undeclared identifier
+means you referenced a `custom_input` name that isn't wired). Recompile first if you just
+edited it. Don't guess from screenshots.

--- a/.claude/skills/material-authoring/references/glsl_hlsl_mapping.md
+++ b/.claude/skills/material-authoring/references/glsl_hlsl_mapping.md
@@ -1,0 +1,42 @@
+# GLSL -> HLSL (UE Custom node) translation table
+
+Apply mechanically when porting GLSL/ShaderToy into a `MaterialExpressionCustom` body.
+
+## Types
+| GLSL | HLSL |
+|---|---|
+| `vec2` `vec3` `vec4` | `float2` `float3` `float4` |
+| `ivec*` / `uvec*` | `int*` / `uint*` |
+| `mat2` `mat3` `mat4` | `float2x2` `float3x3` `float4x4` |
+| `bvec*` | `bool*` |
+
+## Functions
+| GLSL | HLSL |
+|---|---|
+| `mix(a,b,t)` | `lerp(a,b,t)` |
+| `fract(x)` | `frac(x)` |
+| `mod(a,b)` | `fmod(a,b)` - differs for negatives; use `a - b*floor(a/b)` to match GLSL |
+| `inversesqrt(x)` | `rsqrt(x)` |
+| `dFdx` `dFdy` | `ddx` `ddy` |
+| `atan(y,x)` | `atan2(y,x)` |
+| `texture(s,uv)` | `Texture2DSample(s, sSampler, uv)` |
+| `textureLod(s,uv,l)` | `Texture2DSampleLevel(s, sSampler, uv, l)` |
+| `clamp/min/max/abs/floor/ceil/...` | same names |
+
+## Matrix math
+- GLSL is column-major, HLSL row-major. `M * v` (GLSL) usually becomes `mul(v, M)` or `mul(M, v)` - if a rotation looks transposed, swap the `mul` operand order.
+- Construct: `mat2(a,b,c,d)` -> `float2x2(a,b,c,d)`.
+
+## Built-ins / globals
+| GLSL | HLSL (UE Custom) |
+|---|---|
+| `gl_FragCoord.xy` | `Parameters.SvPosition.xy` (pixels) |
+| `gl_FragColor` | the function's `return` value |
+| swizzles (`.xyz`, `.rgb`) | identical |
+
+## Gotchas
+- Integer vs float division: `1/2` is `0`. Write `1.0/2.0`.
+- HLSL has no implicit `int`->`float` in some ops; prefer float literals.
+- Arrays declared `const float k[3] = float[](...)` (GLSL) -> `const float k[3] = {...};` (HLSL).
+- No `#version`, no `precision` qualifiers - delete them.
+- The Custom node `Code` is a function *body*: end with `return <OutputType-typed value>;`.

--- a/.claude/skills/material-authoring/references/shadertoy_inputs.md
+++ b/.claude/skills/material-authoring/references/shadertoy_inputs.md
@@ -1,0 +1,38 @@
+# ShaderToy uniforms -> UE Custom-node inputs
+
+ShaderToy's entry point is `void mainImage(out vec4 fragColor, in vec2 fragCoord)`. Translate
+its implicit uniforms to graph nodes wired into named `custom_inputs` (don't hardcode them).
+
+| ShaderToy | UE node -> custom_input | Notes |
+|---|---|---|
+| `fragCoord.xy / iResolution.xy` (normalized UV) | `MaterialExpressionTextureCoordinate` -> `UV` (float2) | The usual `uv` in ShaderToy. Most shaders start with `vec2 uv = fragCoord/iResolution.xy;` - just use the `UV` input directly. |
+| `iResolution` (pixel size) | `VectorParameter` -> `Resolution`, or skip | Only needed if the shader uses absolute pixels. For aspect-correct UV: `UV * float2(Aspect, 1)`. |
+| `iTime` | `MaterialExpressionTime` -> `Time` (float) | Seconds. Animates only in PIE/Realtime. |
+| `iTimeDelta` | not available | Use a small constant if needed. |
+| `iFrame` | not available | Approximate with `floor(Time * fps)`. |
+| `iChannel0..3` (sampler2D) | `MaterialExpressionTextureObjectParameter` -> `Tex0..3` | Sample with `Texture2DSample(Tex0, Tex0Sampler, uv)`. Each texture input auto-gets a `<Name>Sampler`. |
+| `iChannelResolution[n]` | `VectorParameter` if needed | Rarely used. |
+| `iMouse` | `VectorParameter` -> `Mouse` (for testing) | No live mouse in a material. |
+| `iDate`, `iSampleRate` | not available | Drop. |
+
+## Standard skeleton
+
+ShaderToy:
+```glsl
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord/iResolution.xy;
+    vec3 col = 0.5 + 0.5*cos(iTime + uv.xyx + vec3(0,2,4));
+    fragColor = vec4(col, 1.0);
+}
+```
+
+Becomes a Custom node (`OutputType: CMOT_Float3`, `custom_inputs: [UV, Time]`):
+```hlsl
+float3 col = 0.5 + 0.5 * cos(Time + float3(UV, UV.x) + float3(0,2,4));
+return col;
+```
+plus `TextureCoordinate -> UV`, `Time -> Time`, output -> `EmissiveColor`, Unlit.
+
+## Output
+ShaderToy writes RGBA but materials are RGB here: drop alpha, route RGB to `EmissiveColor`
+on an **Unlit** material. Multiply by ~2-8 for bloom on bright/neon shaders.

--- a/.claude/skills/material-authoring/shader_translation/examples/plasma.md
+++ b/.claude/skills/material-authoring/shader_translation/examples/plasma.md
@@ -1,0 +1,54 @@
+# Worked example: ShaderToy cosine-palette plasma
+
+A minimal, animated ShaderToy shader translated end to end. Good template for the pattern.
+
+## Source (ShaderToy)
+```glsl
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+    float t = iTime * 0.5;
+    vec3 col = 0.5 + 0.5 * cos(t + uv.xyx * 6.0 + vec3(0.0, 2.0, 4.0));
+    col *= 0.6 + 0.4 * sin(t + (uv.x + uv.y) * 10.0);
+    fragColor = vec4(col, 1.0);
+}
+```
+
+## Input mapping
+- `uv` (`fragCoord/iResolution`) -> `TextureCoordinate` into a `UV` input
+- `iTime` -> `Time` into a `Time` input
+- no channels/uniforms; the `0.5`, `6.0`, `10.0` stay inline
+
+## Translation (GLSL -> HLSL)
+- `vec3` -> `float3`, `cos`/`sin` unchanged, `uv.xyx` -> `float3(UV, UV.x)`
+- entry point dropped; the body returns a `float3`
+
+## Build spec (verified: compiles clean, animates in PIE)
+```python
+import arbor.materials as mat
+mat.build_material({
+  "path": "/Game/.../M_FX_Plasma",
+  "flags": {"shading_model": "MSM_Unlit", "blend_mode": "BLEND_Opaque"},
+  "expressions": [
+    {"id": "tc",   "class": "MaterialExpressionTextureCoordinate", "properties": {}},
+    {"id": "time", "class": "MaterialExpressionTime", "properties": {}},
+    {"id": "cust", "class": "MaterialExpressionCustom",
+     "properties": {"Description": "cosine-palette plasma", "OutputType": "CMOT_Float3",
+       "Code": "float t = Time * 0.5;\nfloat3 col = 0.5 + 0.5 * cos(t + float3(UV, UV.x) * 6.0 + float3(0.0, 2.0, 4.0));\ncol *= 0.6 + 0.4 * sin(t + (UV.x + UV.y) * 10.0);\nreturn col;"},
+     "custom_inputs": [{"name": "UV"}, {"name": "Time"}]},
+  ],
+  "connections": [
+    {"from": "tc",   "to": "cust", "to_input": "UV"},
+    {"from": "time", "to": "cust", "to_input": "Time"},
+  ],
+  "outputs": [{"from": "cust", "property": "EmissiveColor"}],
+  # auto_layout on by default -> graph opens tidy
+})
+```
+
+## Validate
+- `query_material(path).compile_errors` -> `[]`
+- `render_thumbnail` shows the plasma palette (a still frame; it animates only in PIE/Realtime because of `Time`).
+
+## Notes
+- `cos`/`sin` over `Time` is the animation; multiply the result by ~2-6 if you want it to bloom.
+- Because everything is wired through `UV`/`Time` inputs (not `Parameters.*`), the node is reusable and the inputs are swappable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,10 @@ Granular material editing lives in `UArborMaterialGraphTools` (MCP `ue5_material
 
 `layout(path)` / `arbor.materials.layout_material(path)` auto-arranges a material's or material function's nodes into a readable left-to-right column layout. Auto-detects the asset type, no editor window needed, no recompile (it only moves nodes). Materials use UE's built-in `LayoutMaterialExpressions`; functions use Arbor's own layered layout (`LayoutFunctionGraph`), because UE's `LayoutMaterialFunctionExpressions` only positions input nodes for functions that have inputs and leaves the rest piled at the origin. `build_material` / `build_material_function` run this automatically at the end so Arbor-built graphs open tidy instead of as a pile of overlapping nodes at the origin. On by default; it overrides any manual `x`/`y` in the spec, so pass `"auto_layout": false` to keep hand-placed positions.
 
+### Custom HLSL nodes
+
+`MaterialExpressionCustom` is supported by `build_material` / `build_material_function` / `add_expression`. `Code` (an HLSL function body that must `return` the output type), `OutputType` (`CMOT_Float1`..`CMOT_Float4` or `CMOT_MaterialAttributes`), and `Description` are normal `properties`; the named input pins go in a **top-level `custom_inputs`** array on the expression (`[{"name":"UV"},{"name":"Scale"}]`) - each becomes an input pin AND an HLSL variable, wired via the usual `connections`. Sample textures with `Texture2DSample(Tex, TexSampler, uv)` (not `tex2D`/`texture`). Full HLSL scope + GLSL->HLSL cheatsheet: the skill's `references/custom_node_context.md`.
+
 ### Material Functions (authoring)
 
 `build_material_function(spec)` / `query_material_function(path)` author a `UMaterialFunction` with the same spec shape as `build_material`, with these differences:

--- a/Source/Arbor/Private/ArborMaterialGraphTools.cpp
+++ b/Source/Arbor/Private/ArborMaterialGraphTools.cpp
@@ -26,6 +26,7 @@
 #include "Materials/MaterialExpressionFunctionInput.h"
 #include "Materials/MaterialExpressionFunctionOutput.h"
 #include "Materials/MaterialExpressionComponentMask.h"
+#include "Materials/MaterialExpressionCustom.h"
 #include "Factories/MaterialFunctionFactoryNew.h"
 #include "Materials/MaterialExpressionVectorParameter.h"
 #include "Materials/MaterialParameters.h"
@@ -407,6 +408,31 @@ namespace
 			}
 		}
 		RunPostPropertyHooks(Expr);
+	}
+
+	// MaterialExpressionCustom's named HLSL input pins live in a TArray<FCustomInput>
+	// that the generic reflection setter can't populate. Read a top-level "custom_inputs"
+	// array ([{ "name": "UV" }, ...]) off the expression spec and rebuild the Inputs list
+	// so each name becomes a connectable pin. Code/OutputType/Description go through normal
+	// properties. No-op for non-Custom expressions or when custom_inputs is absent.
+	void ApplyCustomNodeInputs(UMaterialExpression* Expr, const TSharedPtr<FJsonObject>& Spec)
+	{
+		UMaterialExpressionCustom* Custom = Cast<UMaterialExpressionCustom>(Expr);
+		if (!Custom || !Spec.IsValid()) return;
+		const TArray<TSharedPtr<FJsonValue>>* InputsArr = nullptr;
+		if (!Spec->TryGetArrayField(TEXT("custom_inputs"), InputsArr) || !InputsArr) return;
+
+		Custom->Inputs.Reset();
+		for (const TSharedPtr<FJsonValue>& V : *InputsArr)
+		{
+			const TSharedPtr<FJsonObject> Obj = V->AsObject();
+			if (!Obj.IsValid()) continue;
+			FString Name;
+			Obj->TryGetStringField(TEXT("name"), Name);
+			FCustomInput NewInput;
+			NewInput.InputName = FName(*Name);
+			Custom->Inputs.Add(NewInput);
+		}
 	}
 }
 
@@ -832,6 +858,7 @@ FString UArborMaterialGraphTools::AddMaterialExpression(const FString& ParamsJso
 	{
 		ApplyExpressionProperties(Expr, *PropsObj);
 	}
+	ApplyCustomNodeInputs(Expr, Params);
 
 	Mat->MarkPackageDirty();
 
@@ -1034,6 +1061,7 @@ namespace
 		{
 			ApplyExpressionProperties(Expr, *PropsObj);
 		}
+		ApplyCustomNodeInputs(Expr, ExprSpec);
 		return true;
 	}
 }
@@ -1448,6 +1476,7 @@ namespace
 		{
 			ApplyExpressionProperties(Expr, *PropsObj);
 		}
+		ApplyCustomNodeInputs(Expr, ExprSpec);
 		return true;
 	}
 


### PR DESCRIPTION
## Summary

Adds Custom HLSL node support and a shader-translation workflow to the material-authoring pipeline.

**Phase 5 - Custom HLSL nodes.** `MaterialExpressionCustom` is now supported by `build_material` / `build_material_function` / `add_expression`:
- `Code` (HLSL function body), `OutputType` (`CMOT_Float1..4` / `CMOT_MaterialAttributes`), `Description` set via normal `properties`.
- Named HLSL input pins via a top-level **`custom_inputs`** array (`[{"name":"UV"},...]`) - `ApplyCustomNodeInputs` rebuilds the node's `TArray<FCustomInput>` so each name is a connectable pin and an HLSL variable. The generic reflection setter can't do this.
- Reference doc `custom_node_context.md` (HLSL scope, `Texture2DSample`, limits).

**Phase 6 - shader translation.** The `material-authoring` skill now handles pasted GLSL/HLSL/ShaderToy by wrapping the math in a Custom node:
- "Shader translation" section in `SKILL.md` (identify -> map inputs -> GLSL->HLSL pass -> Unlit/EmissiveColor -> validate).
- References `glsl_hlsl_mapping.md` (syntax table) and `shadertoy_inputs.md` (uniform -> UE-node map).
- Worked `plasma.md` example.

## Validation
- Custom node: const-color HLSL and `frac(UV*8)` UV-input HLSL both compile clean (`compile_errors: []`) and render; `custom_inputs` pins resolve and the HLSL sees the variables.
- Translation: a ShaderToy cosine-palette plasma -> Custom-node material compiles, renders, and animates via a `Time` input.
- Several from-scratch effects authored on top of this (plasma, FBM nebula, voronoi, raymarched orb) for the GYM_VFX_Showcase (project-side).

Follow-up to the material-functions / auto-layout work (PRs #26, #27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
